### PR TITLE
Enable JaCoCo reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: chmod +x ./gradlew
 
     - name: Build & test (Gradle)
-      run: ./gradlew clean build --no-daemon
+      run: ./gradlew clean jacocoTestReport --no-daemon
 
     - name: Upload node JAR (artifact)
       uses: actions/upload-artifact@v4

--- a/blockchain-core/build.gradle
+++ b/blockchain-core/build.gradle
@@ -28,4 +28,11 @@ java {
     toolchain { languageVersion = JavaLanguageVersion.of(17) }
 }
 
-tasks.named('test') { useJUnitPlatform() }
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+}

--- a/blockchain-node/build.gradle
+++ b/blockchain-node/build.gradle
@@ -51,3 +51,12 @@ compileOnly          'org.projectlombok:lombok:1.18.30'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+}


### PR DESCRIPTION
## Summary
- generate JaCoCo reports for `blockchain-core` and `blockchain-node`
- update CI workflow to run `jacocoTestReport`

## Testing
- `./gradlew clean jacocoTestReport --no-daemon` *(fails: Could not download spring-boot-buildpack-platform-3.5.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6844cb269c9c83269e8f9065e62258d2