### PR TITLE
Refine blockchain UI layout and tests

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Simple Blockchain</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -55,6 +55,11 @@ export default function App() {
 
   return (
     <>
+      <header className="bg-indigo-600 text-white shadow">
+        <div className="mx-auto max-w-6xl p-4">
+          <h1 className="text-2xl font-semibold">Simple Blockchain</h1>
+        </div>
+      </header>
       <Dashboard />
       <Toaster position="top-right" reverseOrder={false} />
     </>

--- a/ui/src/__tests__/app.test.tsx
+++ b/ui/src/__tests__/app.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+
+vi.mock('../pages/Dashboard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="dashboard" />,
+}));
+
+vi.mock('./../api/ws', () => ({
+  wsSingleton: { connect: vi.fn(), close: vi.fn(), on: vi.fn() },
+}));
+
+it('renders app header', () => {
+  render(<App />);
+  expect(screen.getByRole('heading', { name: /simple blockchain/i })).toBeInTheDocument();
+  expect(screen.getByTestId('dashboard')).toBeInTheDocument();
+});

--- a/ui/src/__tests__/dashboard.test.tsx
+++ b/ui/src/__tests__/dashboard.test.tsx
@@ -35,7 +35,11 @@ describe('<Dashboard />', () => {
   it('renders chain info cards', () => {
     render(<Dashboard />);
 
+    expect(screen.getByRole('heading', { name: /chain info/i })).toBeInTheDocument();
     expect(screen.getByText(/block height/i)).toBeInTheDocument();
+    expect(screen.getByText(/difficulty bits/i)).toBeInTheDocument();
+    expect(screen.getByText(/latest hash/i)).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByTestId('wallet-view')).toBeInTheDocument();
   });
 });

--- a/ui/src/__tests__/transfer.test.tsx
+++ b/ui/src/__tests__/transfer.test.tsx
@@ -1,4 +1,4 @@
-// __tests__/transfer.test.tsx – aktualisiert
+// __tests__/transfer.test.tsx - aktualisiert
 // ---------------------------------------------------------------------------
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/ui/src/components/MiningArea.tsx
+++ b/ui/src/components/MiningArea.tsx
@@ -7,8 +7,8 @@ import type { Block } from '../types/block';
 // …unverändert…
 function BlockDetails({ block }: { block: Block }) {
   return (
-    <div className="mt-6 p-4 bg-white bg-opacity-20 rounded-lg">
-      <h3 className="text-xl font-semibold mb-2">Newly Mined Block</h3>
+    <div className="mt-6 rounded-lg bg-white/20 p-4">
+      <h3 className="mb-2 text-xl font-semibold">Newly Mined Block</h3>
       <ul className="space-y-1 text-sm font-mono">
         <li><strong>Height: {block.height}</strong></li>
         <li><strong>Difficulty Bits:</strong> {block.compactDifficultyBits}</li>
@@ -29,15 +29,16 @@ export function MineArea() {
     try {
       const newBlock = await post<Block>('/mining/mine');
       setBlock(newBlock);
-    } catch (err: any) {
-      setError(err.message ?? 'Unknown error');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setError(msg);
     } finally {
       setIsMining(false);
     }
   };
 
   return (
-    <section className="bg-gradient-to-r from-purple-500 to-indigo-600 p-6 rounded-2xl shadow-lg text-white">
+    <section className="rounded-xl bg-gradient-to-r from-purple-600 to-indigo-700 p-6 text-white shadow-lg">
       <h2 className="text-2xl font-bold mb-4">Mine a New Block</h2>
       <button
         onClick={doMine}

--- a/ui/src/components/Transfer.tsx
+++ b/ui/src/components/Transfer.tsx
@@ -61,10 +61,10 @@ export function Transfer() {
     setErrorMsg(null);
   };
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setOpen(false);
     resetForm();
-  };
+  }, []);
 
   /* ------------------------------------------------------------------------ */
   /* Submit handler                                                           */
@@ -96,11 +96,11 @@ export function Transfer() {
         /* ------------------------------------------------------------------ */
         /* Optimistic SWR cache update – decrease confirmed balance           */
         /* ------------------------------------------------------------------ */
-        mutate(
-          '/wallet',
-          (current: any) =>
-            current && typeof current.confirmedBalance === 'number'
-              ? {
+          mutate(
+            '/wallet',
+            (current: { confirmedBalance?: number } | undefined) =>
+              current && typeof current.confirmedBalance === 'number'
+                ? {
                   ...current,
                   confirmedBalance: current.confirmedBalance - amount,
                 }
@@ -129,7 +129,7 @@ export function Transfer() {
 
         /*       ✅ Alles ok – Formular zurücksetzen und Modal schließen      */
         closeModal();
-      } catch (err) {
+      } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : 'Transaction failed';
         setErrorMsg(msg);
         toast.error(msg);
@@ -137,7 +137,7 @@ export function Transfer() {
         setSubmitting(false);
       }
     },
-    [recipient, amountStr],
+    [closeModal, recipient, amountStr],
   );
 
   /* ------------------------------------------------------------------------ */

--- a/ui/src/components/WalletView.tsx
+++ b/ui/src/components/WalletView.tsx
@@ -29,7 +29,7 @@ export default function WalletView() {
   return (
     <section className="grid gap-6 md:grid-cols-2">
       {/* Address / QR / Balances ------------------------------------------- */}
-      <div className="rounded-lg border p-4 shadow">
+      <div className="rounded-lg bg-white shadow p-6">
         <h2 className="mb-2 font-bold">Your address</h2>
         <code aria-label={data.address} className="block break-all">
           {data.address}
@@ -74,8 +74,10 @@ export default function WalletView() {
       </div>
 
       {/* Mining + Transfer -------------------------------------------------- */}
-      <MineArea />
-      <Transfer />
+      <div className="space-y-6">
+        <MineArea />
+        <Transfer />
+      </div>
     </section>
   );
 }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -12,14 +12,18 @@ export default function Dashboard() {
   );
 
   return (
-    <main className="max-w-6xl mx-auto p-4 grid gap-4 md:grid-cols-3">
-      <div>
-        <h1>Chain info</h1>
-        <StatCard label="Block height" value={tip?.height ?? '…'} />
-        <StatCard label="Difficulty bits" value={tip?.compactDifficultyBits ?? '…'} />
-        <StatCard label="Latest hash" value={tip ? tip.hashHex.slice(0, 16) : '…'} />
+    <main className="mx-auto max-w-6xl px-4 py-6 grid gap-6 md:grid-cols-3">
+      <section className="space-y-4" aria-label="chain info">
+        <h2 className="text-lg font-semibold">Chain info</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+          <StatCard label="Block height" value={tip?.height ?? '…'} />
+          <StatCard label="Difficulty bits" value={tip?.compactDifficultyBits ?? '…'} />
+          <StatCard label="Latest hash" value={tip ? tip.hashHex.slice(0, 16) : '…'} />
+        </div>
+      </section>
+      <div className="md:col-span-2">
+        <WalletView />
       </div>
-      <WalletView />
-      </main>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- modernize frontend layout with Tailwind styling
- display header 'Simple Blockchain'
- adapt wallet and mining components for a cleaner look
- update vitest suites for revised layout

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68487357420c8326b76e1901e386e738