### PR TITLE
Add detailed AGENTS docs

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,1 +1,5 @@
-Workflow files for GitHub Actions are stored here. `ci.yml` builds and tests the project using Gradle and uploads the built JARs as artifacts.
+GitHub Actions workflows live in this directory.
+
+- `workflows/ci.yml` sets up JDK 17, caches Gradle and runs
+  `./gradlew clean jacocoTestReport`. Successful builds upload the node and
+  core JARs as artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,32 @@
-This repository contains a proof-of-concept blockchain implementation. The following directories host all source code:
+This repository contains a proof-of-concept blockchain with three main modules.
 
-- `blockchain-core` – Java library with blockchain data structures and consensus logic.
-- `blockchain-node` – Spring Boot application that exposes REST and WebSocket APIs and coordinates mining, mempool and networking.
-- `ui` – React + TypeScript front‑end.
-- `gradle` – Gradle wrapper and dependency version catalog.
+Directories and notable files
+-----------------------------
+- `blockchain-core/` – Java library with data models and consensus logic.
+  - `build.gradle` configures library dependencies.
+  - `src/main/java` holds packages `consensus`, `crypto`, `model`, `mempool`,
+    `serialization` and `exceptions`.
+- `blockchain-node/` – Spring Boot application built on the core library.
+  - `build.gradle` defines the Spring Boot plugin and dependencies.
+  - `src/main/java/de/flashyotter/blockchain_node` contains configuration,
+    REST controllers, services and P2P networking.
+- `ui/` – React + TypeScript front-end for interacting with the node.
+  - `package.json` and `vite.config.ts` drive the Node build.
+  - `src` holds React components and API helpers.
+- `gradle/` – Gradle wrapper and version catalog `libs.versions.toml`.
+- `data/` – runtime LevelDB store for blocks and wallet.
+- `settings.gradle` – lists included modules.
+- `README.md` – build and usage instructions.
 
-Other items include test resources under each module, and persistent `data` for LevelDB blocks.
+Overall relationship
+--------------------
+```plantuml
+@startuml
+actor User
+User -> UI: browse
+UI --> "blockchain-node": REST/WS calls
+"blockchain-node" --> "blockchain-core": library usage
+@enduml
+```
+
+Each module creates a `build/` directory with compiled classes and test reports after running Gradle. These outputs are not tracked in version control.

--- a/blockchain-core/AGENTS.md
+++ b/blockchain-core/AGENTS.md
@@ -1,13 +1,14 @@
-`blockchain-core` is a standalone Java library that implements the core blockchain logic.
+`blockchain-core` is a standalone Java library implementing the fundamental
+blockchain data structures and algorithms.
 
-Directories:
-- `src/main/java/blockchain/core` contains all source packages:
-  - `model` – block, transaction and wallet classes
-  - `consensus` – chain data structure and difficulty retarget
-  - `crypto` – helpers for hashing and addresses
-  - `mempool` – in-memory transaction pool
-  - `serialization` – JSON utilities
-  - `exceptions` – domain-specific runtime exception
-- `src/test/java` provides unit tests for these packages.
+Packages under `src/main/java/blockchain/core`:
+- `consensus` – `Chain.java` manages the block DAG and difficulty, while
+  `ConsensusParams.java` defines PoW constants.
+- `crypto` – utilities like `AddressUtils`, `CryptoUtils` and `HashingUtils`.
+- `model` – `Block`, `Transaction`, `Wallet` and related classes.
+- `mempool` – simple in-memory `Mempool` for pending transactions.
+- `serialization` – JSON helpers (`JsonUtils`).
+- `exceptions` – custom runtime `BlockchainException`.
 
-Build settings live in `build.gradle` and the module can be built independently.
+Tests in `src/test/java` mirror these packages. Build logic resides in
+`build.gradle`.

--- a/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java.agent.md
+++ b/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java.agent.md
@@ -1,0 +1,4 @@
+Core implementation of the blockchain DAG. Manages all seen blocks and selects
+the branch with the most cumulative Proof-of-Work. Also rebuilds the UTXO set
+whenever a reorganisation occurs. Used by `NodeService` to append blocks and
+obtain difficulty via `nextCompactBits()`.

--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -1,10 +1,22 @@
-`blockchain-node` hosts the Spring Boot application exposing the blockchain over REST and WebSockets. Key directories in `src/main/java/de/flashyotter/blockchain_node`:
-- `config` – Spring configuration and properties
-- `controler` – REST controllers for chain, transactions, mining and wallet
-- `service` – application services coordinating the core library, P2P network and mining
-- `p2p` – WebSocket peer client/server implementation
-- `storage` – interfaces and implementations for persisting blocks (LevelDB or in-memory)
-- `wallet` – key store and wallet utilities
-- `bootstrap` – startup tasks executed when the node launches
+`blockchain-node` contains the Spring Boot application built on `blockchain-core`.
 
-Resources under `src/main/resources` contain the YAML configuration. Tests mirror the package structure under `src/test`.
+Important paths under `src/main/java/de/flashyotter/blockchain_node`:
+- `BlockchainNodeApplication.java` – entry point starting the HTTP & WebSocket server.
+- `bootstrap/StartupInitializer.java` – tasks executed at startup.
+- `config/` – Spring configuration classes (`SecurityConfig`, `WebSocketConfig`, ...).
+- `controler/` – REST controllers for chain, mining, transactions and wallet.
+- `service/` – business logic (`NodeService`, `MiningService`, etc.).
+- `p2p/` – `Peer`, `PeerClient` and `PeerServer` for WebSocket networking.
+- `storage/` – `BlockStore` with LevelDB and in-memory implementations.
+- `wallet/` – wallet and keystore utilities.
+
+Resources in `src/main/resources` define application defaults. Tests in
+`src/test` cover controllers, services and networking.
+
+```plantuml
+@startuml
+NodeService -> MiningService: mine()
+MiningService -> Chain: difficulty + latest block
+NodeService -> P2PBroadcastService: broadcastBlock()
+@enduml
+```

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
@@ -1,0 +1,3 @@
+Represents a remote blockchain node. Provides the `wsUrl()` helper to build the
+WebSocket endpoint and a `fromString` factory to parse `host:port` pairs. Used by
+`PeerService` and networking tests.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
@@ -1,8 +1,16 @@
-Services coordinating blockchain operations live in this package.
+This package contains the services composing the node.
 
-- `NodeService` – central orchestrator for chain, mempool and mining
-- `MiningService` – CPU miner producing new blocks
-- `MempoolService` – manages pending transactions
-- `P2PBroadcastService` / `P2PBroadcastPort` – send events to peers
-- `PeerService` / `PeerRegistry` – track and discover peers
-- `DiscoveryLoop` and `SyncService` – maintain network connectivity and sync state
+- `NodeService` – orchestrates chain state, mining and broadcasting.
+- `MiningService` – builds candidate blocks from the mempool and performs PoW.
+- `MempoolService` – holds unconfirmed transactions.
+- `P2PBroadcastService` (via `P2PBroadcastPort`) – sends blocks and txs to peers.
+- `PeerService` with `PeerRegistry` – manages the list of known peers.
+- `DiscoveryLoop` and `SyncService` – keep peers connected and the chain synced.
+
+```plantuml
+@startuml
+NodeService -> MiningService: mine()
+NodeService -> MempoolService: submitTx()
+NodeService -> P2PBroadcastService: broadcast()
+@enduml
+```

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MiningService.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MiningService.java.agent.md
@@ -1,0 +1,3 @@
+`MiningService` assembles transactions from the `MempoolService` and performs
+proof-of-work. `NodeService` invokes `mine()` to create the next block using
+the difficulty returned from the `Chain`.

--- a/gradle/AGENTS.md
+++ b/gradle/AGENTS.md
@@ -1,1 +1,4 @@
-Contains Gradle wrapper files and the version catalog `libs.versions.toml`. No source code here, only build tooling.
+Gradle wrapper files and the shared version catalog.
+
+- `wrapper/` – `gradle-wrapper.jar` and properties used to bootstrap Gradle.
+- `libs.versions.toml` – central place for dependency versions.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,8 +1,11 @@
-The `ui` directory contains a Vite + React front-end used to interact with the blockchain node.
+The `ui` directory contains a Vite + React front-end used to interact with the node.
 
-Important files:
-- `index.html` – HTML page served during development and build
-- `src` – TypeScript source with React components and tests
-- `package.json` / `package-lock.json` – Node build configuration
+Key files:
+- `index.html` – main HTML page for development and production.
+- `package.json` / `package-lock.json` – Node dependencies and scripts.
+- `build.gradle` – helper tasks for running `npm` from Gradle.
+- `vite.config.ts` – Vite build configuration.
+- `src/` – TypeScript sources and tests.
+- `tsconfig*.json` – TypeScript compiler settings.
 
-Run `npm install` then `npm run dev` to launch the development server.
+Run `npm install` then `npm run dev` in this directory to start the dev server.

--- a/ui/src/AGENTS.md
+++ b/ui/src/AGENTS.md
@@ -1,10 +1,11 @@
-`src` holds the TypeScript source for the web UI.
+Source code for the web front-end.
 
-Subdirectories:
-- `api` – helper functions for REST and WebSocket calls
-- `components` – React UI components such as mining and wallet views
-- `pages` – top level routes (currently only `Dashboard`)
-- `types` – shared TypeScript interfaces
-- `__tests__` – Jest/Testing Library unit tests
+Folders:
+- `api/` – REST (`rest.ts`) and WebSocket (`ws.ts`) helpers.
+- `components/` – React components: `MiningArea`, `Transfer`, `StatCard`, `WalletView`.
+- `pages/` – top level views, currently just `Dashboard.tsx`.
+- `types/` – shared TypeScript interfaces.
+- `assets/` – static assets such as `react.svg`.
+- `__tests__/` – unit tests for components and pages.
 
-Entry file `main.tsx` boots the React application.
+Entry point `main.tsx` bootstraps React.

--- a/ui/src/api/rest.ts.agent.md
+++ b/ui/src/api/rest.ts.agent.md
@@ -1,0 +1,3 @@
+Wraps the browser `fetch` API for the UI. Functions `get` and `post` prefix
+requests with the `VITE_NODE_URL` environment variable so the front-end can
+access the node REST API.


### PR DESCRIPTION
## Summary
- expand AGENTS descriptions in every module
- document important files
- add PlantUML snippets showing module relationships
- add file specific agent docs for Chain, MiningService, Peer and REST helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684890bb88048326b6c3a5b8cecf29ef