### PR TITLE
Add message service and raw transaction UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Peers in `application.yml → node.peers` are contacted automatically.
 
 | Method & Path | Payload | Description |
 |---------------|---------|-------------|
-| **GET** `/api/wallet/info` | – | Public key + confirmed balance |
+| **GET** `/api/wallet` | – | Public key + confirmed balance |
 | **POST** `/api/wallet/send` | `{ "recipient":"&lt;base64&gt;", "amount":1.23 }` | Builds + signs + broadcasts a TX |
 | **POST** `/api/tx` | raw `Transaction` JSON | Submit an already-signed TX |
 | **POST** `/api/mining/mine` | – | Mine one block immediately |
@@ -48,7 +48,7 @@ Example:
 
 ```bash
 # my wallet address & balance
-curl http://localhost:8080/api/wallet/info | jq
+curl http://localhost:8080/api/wallet | jq
 
 # pay 1.0 coin to recipientKey
 curl -X POST http://localhost:8080/api/wallet/send \

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { mutate } from 'swr';
-import toast, { Toaster } from 'react-hot-toast';
-import { CheckBadgeIcon } from '@heroicons/react/24/solid';
+import { Toaster } from 'react-hot-toast';
+import { messageService } from './services/messageService';
 import { wsSingleton } from './api/ws';
 import Dashboard from './pages/Dashboard';
 
@@ -29,26 +29,7 @@ export default function App() {
 
         mutate('/chain/latest');
         mutate('/wallet');
-
-        toast.custom(
-          t => (
-            <div
-              className={`${
-                t.visible ? 'animate-enter' : 'animate-leave'
-              } pointer-events-auto flex w-full max-w-sm rounded-lg bg-slate-800 p-4 shadow-lg ring-1 ring-black ring-opacity-5`}
-              role="status"
-            >
-              <CheckBadgeIcon
-                className="h-6 w-6 shrink-0 text-green-400"
-                aria-hidden="true"
-              />
-              <div className="ml-3 flex-1 text-sm text-white">
-                New block #{blk.height} accepted
-              </div>
-            </div>
-          ),
-          { duration: 4000 },
-        ); /* :contentReference[oaicite:0]{index=0} */
+        messageService.success(`New block #${blk.height} accepted`);
       }
     });
   }, []);

--- a/ui/src/__tests__/app.test.tsx
+++ b/ui/src/__tests__/app.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../pages/Dashboard', () => ({
 vi.mock('./../api/ws', () => ({
   wsSingleton: { connect: vi.fn(), close: vi.fn(), on: vi.fn() },
 }));
+vi.mock('../services/messageService', () => ({
+  messageService: { success: vi.fn(), error: vi.fn() },
+}));
 
 it('renders app header', () => {
   render(<App />);

--- a/ui/src/__tests__/dashboard.test.tsx
+++ b/ui/src/__tests__/dashboard.test.tsx
@@ -22,6 +22,10 @@ vi.mock('../components/BlockList', () => ({
   __esModule: true,
   default: () => <div data-testid="block-list" />,
 }));
+vi.mock('../components/RawTxSubmit', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rawtx" />,
+}));
 
 /* useSWR stubben, damit Chain-Info sofort im State ist -------------------- */
 vi.mock('swr', () => ({

--- a/ui/src/__tests__/miningarea.test.tsx
+++ b/ui/src/__tests__/miningarea.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MineArea } from '../components/MiningArea';
 
+vi.mock('../services/messageService', () => ({
+  messageService: { success: vi.fn(), error: vi.fn() },
+}));
+
 vi.mock('../api/rest', () => ({
   post: vi.fn(() =>
     Promise.resolve({

--- a/ui/src/__tests__/rawtxsubmit.test.tsx
+++ b/ui/src/__tests__/rawtxsubmit.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RawTxSubmit from '../components/RawTxSubmit';
+
+vi.mock('../api/rest', () => ({
+  __esModule: true,
+  post: vi.fn(),
+}));
+vi.mock('../services/messageService', () => ({
+  messageService: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('<RawTxSubmit />', () => {
+  it('submits parsed JSON to /tx', async () => {
+    const { post } = await import('../api/rest');
+    render(<RawTxSubmit />);
+    fireEvent.change(screen.getByLabelText(/raw-tx-json/i), {
+      target: { value: '{"foo":1}' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+    expect(post).toHaveBeenCalledWith('/tx', { foo: 1 });
+  });
+});

--- a/ui/src/__tests__/transfer.test.tsx
+++ b/ui/src/__tests__/transfer.test.tsx
@@ -4,6 +4,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Transfer } from '../components/Transfer';
 
+vi.mock('../services/messageService', () => ({
+  messageService: { success: vi.fn(), error: vi.fn() },
+}));
+
 /* ------------------------------------------------------------------ */
 /* REST‑Modul mocken – EIN Objekt exportieren, damit alle Tests dieselbe
    Mock‑Funktion verwenden können.                                    */

--- a/ui/src/components/MiningArea.tsx
+++ b/ui/src/components/MiningArea.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CpuChipIcon } from '@heroicons/react/24/outline';
 import { post } from '../api/rest';
+import { messageService } from '../services/messageService';
 import type { Block } from '../types/block';
 
 // Subcomponent to render block details
@@ -21,17 +22,16 @@ function BlockDetails({ block }: { block: Block }) {
 export function MineArea() {
   const [block, setBlock] = useState<Block | null>(null);
   const [isMining, setIsMining] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const doMine = async () => {
     setIsMining(true);
-    setError(null);
     try {
       const newBlock = await post<Block>('/mining/mine');
       setBlock(newBlock);
+      messageService.success(`Mined block #${newBlock.height}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
-      setError(msg);
+      messageService.error(msg);
     } finally {
       setIsMining(false);
     }
@@ -49,12 +49,6 @@ export function MineArea() {
         <CpuChipIcon className={`h-6 w-6 mr-2 ${isMining ? 'animate-spin' : ''}`} aria-hidden="true" />
         <span>{isMining ? 'Mining...' : 'Start Mining'}</span>
       </button>
-
-      {error && (
-        <p className="mt-4 text-red-300" role="alert">
-          {error}
-        </p>
-      )}
 
       {block && <BlockDetails block={block} />}
     </section>

--- a/ui/src/components/RawTxSubmit.tsx
+++ b/ui/src/components/RawTxSubmit.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { post } from '../api/rest';
+import { messageService } from '../services/messageService';
+
+export default function RawTxSubmit() {
+  const [raw, setRaw] = useState('');
+  const [busy, setBusy] = useState(false);
+  const submit = async () => {
+    setBusy(true);
+    try {
+      const tx = JSON.parse(raw);
+      await post('/tx', tx);
+      setRaw('');
+      messageService.success('Transaction submitted');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Invalid JSON';
+      messageService.error(msg);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <section className="rounded-lg bg-white shadow p-4 space-y-2" aria-label="raw transaction submit">
+      <h2 className="text-lg font-semibold">Submit Raw Transaction</h2>
+      <textarea
+        aria-label="raw-tx-json"
+        className="w-full rounded border-slate-300 p-2 font-mono"
+        rows={5}
+        value={raw}
+        onChange={e => setRaw(e.target.value)}
+      />
+      <button
+        onClick={submit}
+        disabled={busy}
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+      >
+        {busy ? 'Submitting…' : 'Submit'}
+      </button>
+    </section>
+  );
+}

--- a/ui/src/components/Transfer.tsx
+++ b/ui/src/components/Transfer.tsx
@@ -19,12 +19,11 @@ import {
 } from '@headlessui/react';
 import {
   ArrowRightCircleIcon,
-  CheckCircleIcon,
   ExclamationTriangleIcon,
   PaperAirplaneIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import toast from 'react-hot-toast';
+import { messageService } from '../services/messageService';
 import { Fragment, useCallback, useState } from 'react';
 import { mutate } from 'swr';
 import { post } from '../api/rest';
@@ -112,19 +111,8 @@ export function Transfer() {
         /* ------------------------------------------------------------------ */
         /* User feedback                                                      */
         /* ------------------------------------------------------------------ */
-        toast.custom(
-          t => (
-            <p
-              className={`${
-                t.visible ? 'animate-enter' : 'animate-leave'
-              } inline-flex items-center rounded-md bg-green-50 px-3 py-2 text-sm text-green-800 ring-1 ring-inset ring-green-600/20`}
-              role="status"
-            >
-              <CheckCircleIcon className="mr-2 h-5 w-5 text-green-600" aria-hidden="true" />
-              Sent {amount.toFixed(8)} coins to {recipient}
-            </p>
-          ),
-          { duration: 3000 },
+        messageService.success(
+          `Sent ${amount.toFixed(8)} coins to ${recipient}`,
         );
 
         /*       ✅ Alles ok – Formular zurücksetzen und Modal schließen      */
@@ -132,7 +120,7 @@ export function Transfer() {
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : 'Transaction failed';
         setErrorMsg(msg);
-        toast.error(msg);
+        messageService.error(msg);
       } finally {
         setSubmitting(false);
       }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import type { Block } from '../types/block';   // ❶ Type-only-Import
 import { StatCard } from '../components/StatCard';
 import WalletView from '../components/WalletView';
 import BlockList from '../components/BlockList';
+import RawTxSubmit from '../components/RawTxSubmit';
 
 export default function Dashboard() {
   const { data: tip } = useSWR<Block>(
@@ -25,6 +26,7 @@ export default function Dashboard() {
       </section>
       <div className="md:col-span-2 space-y-6">
         <WalletView />
+        <RawTxSubmit />
       </div>
     </main>
   );

--- a/ui/src/services/messageService.tsx
+++ b/ui/src/services/messageService.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+import { CheckBadgeIcon, ExclamationTriangleIcon } from '@heroicons/react/24/solid';
+
+export const messageService = {
+  success(msg: string) {
+    toast.custom(
+      t => (
+        <div
+          className={`${t.visible ? 'animate-enter' : 'animate-leave'} pointer-events-auto flex w-full max-w-sm rounded-lg bg-slate-800 p-4 text-white shadow-lg ring-1 ring-black ring-opacity-5`}
+          role="status"
+        >
+          <CheckBadgeIcon className="h-6 w-6 text-green-400" aria-hidden="true" />
+          <div className="ml-3 flex-1 text-sm">{msg}</div>
+        </div>
+      ),
+      { duration: 4000 },
+    );
+  },
+  error(msg: string) {
+    toast.custom(
+      t => (
+        <div
+          className={`${t.visible ? 'animate-enter' : 'animate-leave'} pointer-events-auto flex w-full max-w-sm rounded-lg bg-red-600/90 p-4 text-white shadow-lg ring-1 ring-black ring-opacity-5`}
+          role="alert"
+        >
+          <ExclamationTriangleIcon className="h-6 w-6" aria-hidden="true" />
+          <div className="ml-3 flex-1 text-sm">{msg}</div>
+        </div>
+      ),
+      { duration: 4000 },
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable `messageService` for toast notifications
- use the service in existing components
- implement `RawTxSubmit` component for `/api/tx`
- mount the new component on the dashboard
- fix README wallet endpoint
- update tests for new component and messaging

## Testing
- `npm test`
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_684c0efd8a708326a45c2f4e22d04364