### PR TITLE
Add wallet history and paginated block view

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controler/ChainController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controler/ChainController.java
@@ -23,4 +23,14 @@ public class ChainController {
     public java.util.List<Block> blocks(@RequestParam(defaultValue = "0") int from) {
         return node.blocksFromHeight(from);
     }
+
+    /**
+     * Paginated list of blocks in descending order.
+     */
+    @GetMapping("/page")
+    public java.util.List<Block> page(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size) {
+        return node.blockPage(page, size);
+    }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controler/WalletController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controler/WalletController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -50,5 +51,14 @@ public class WalletController {
             wallet.getLocalWallet().getPublicKey()
         );
         return new WalletInfoDto(address, balance);
+    }
+
+    /**
+     * Returns recent transactions for a wallet address.
+     */
+    @GetMapping("/transactions")
+    public java.util.List<Transaction> history(@RequestParam String address,
+                                               @RequestParam(defaultValue = "5") int limit) {
+        return node.walletHistory(address, limit);
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/ChainControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/ChainControllerTest.java
@@ -59,4 +59,18 @@ class ChainControllerTest {
 
         verify(nodeSvc, times(1)).blocksFromHeight(5);
     }
+
+    @Test
+    void blockPage() throws Exception {
+        Block b0 = new Block(0, "0".repeat(64),
+            List.of(new blockchain.core.model.Transaction(new Wallet().getPublicKey(), 0)), 0);
+        List<Block> list = List.of(b0);
+        when(nodeSvc.blockPage(1, 5)).thenReturn(list);
+
+        mvc.perform(get("/api/chain/page").param("page", "1").param("size", "5"))
+           .andExpect(status().isOk())
+           .andExpect(content().json(mapper.writeValueAsString(list)));
+
+        verify(nodeSvc, times(1)).blockPage(1, 5);
+    }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
@@ -32,6 +32,7 @@ import de.flashyotter.blockchain_node.controler.WalletController;
 import de.flashyotter.blockchain_node.dto.SendFundsDto;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.wallet.WalletService;
+import java.util.List;
 
 @WebMvcTest(WalletController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -77,5 +78,19 @@ class WalletControllerTest {
            .andExpect(content().json(mapper.writeValueAsString(tx)));
 
         verify(nodeSvc).submitTx(tx);
+    }
+
+    @Test
+    void historyEndpoint() throws Exception {
+        Transaction tx = new Transaction();
+        when(nodeSvc.walletHistory("addr1", 5)).thenReturn(List.of(tx));
+
+        mvc.perform(get("/api/wallet/transactions")
+                .param("address", "addr1")
+                .param("limit", "5"))
+           .andExpect(status().isOk())
+           .andExpect(content().json(mapper.writeValueAsString(List.of(tx))));
+
+        verify(nodeSvc).walletHistory("addr1", 5);
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServicePageTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServicePageTest.java
@@ -1,0 +1,52 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+
+class NodeServicePageTest {
+
+    private Chain chain;
+    private NodeService svc;
+
+    @BeforeEach
+    void setUp() {
+        chain = Mockito.mock(Chain.class);
+        svc = new NodeService(chain,
+                Mockito.mock(MempoolService.class),
+                Mockito.mock(MiningService.class),
+                Mockito.mock(P2PBroadcastService.class),
+                Mockito.mock(de.flashyotter.blockchain_node.storage.BlockStore.class));
+    }
+
+    @Test
+    void returnsPagedBlocks() {
+        // should take the last "size" blocks when paging
+        List<Block> all = List.of(
+            new Block(0, "g", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(1, "a", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(2, "b", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(3, "c", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(4, "d", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(5, "e", List.of(new blockchain.core.model.Transaction()), 0),
+            new Block(6, "f", List.of(new blockchain.core.model.Transaction()), 0)
+        );
+        when(chain.getBlocks()).thenReturn(all);
+
+        List<Block> page0 = svc.blockPage(0, 5);
+        assertEquals(5, page0.size());
+        assertEquals(2, page0.get(0).getHeight());
+
+        List<Block> page1 = svc.blockPage(1, 5);
+        assertEquals(2, page1.size());
+        assertEquals(0, page1.get(0).getHeight());
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceWalletHistoryTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceWalletHistoryTest.java
@@ -1,0 +1,57 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.crypto.AddressUtils;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.TxInput;
+import blockchain.core.model.TxOutput;
+import blockchain.core.model.Wallet;
+
+class NodeServiceWalletHistoryTest {
+
+    private Chain chain;
+    private NodeService svc;
+
+    @BeforeEach
+    void setUp() {
+        chain = Mockito.mock(Chain.class);
+        svc = new NodeService(chain,
+                Mockito.mock(MempoolService.class),
+                Mockito.mock(MiningService.class),
+                Mockito.mock(P2PBroadcastService.class),
+                Mockito.mock(de.flashyotter.blockchain_node.storage.BlockStore.class));
+    }
+
+    @Test
+    void findsRecentTransactionsForAddress() {
+        // collects the latest transactions touching an address
+        Wallet w = new Wallet();
+        String addr = AddressUtils.publicKeyToAddress(w.getPublicKey());
+
+        Transaction tOut = new Transaction();
+        tOut.getOutputs().add(new TxOutput(1.0, addr));
+
+        Transaction tIn = new Transaction();
+        tIn.getInputs().add(new TxInput("foo", new byte[0], w.getPublicKey()));
+
+        List<Block> blocks = List.of(
+            new Block(0, "a", List.of(tOut), 0),
+            new Block(1, "b", List.of(tIn), 0)
+        );
+        when(chain.getBlocks()).thenReturn(blocks);
+
+        List<Transaction> hist = svc.walletHistory(addr, 10);
+        assertEquals(2, hist.size());
+        assertEquals(tIn, hist.get(0));
+    }
+}

--- a/ui/src/__tests__/blockhistory.test.tsx
+++ b/ui/src/__tests__/blockhistory.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import BlockHistory from '../components/BlockHistory';
+
+vi.mock('../api/rest', () => ({ get: vi.fn() }));
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: () => ({
+    data: [
+      { height: 1, compactDifficultyBits: 1, hashHex: 'h1', txList: [] },
+      { height: 2, compactDifficultyBits: 1, hashHex: 'h2', txList: [] },
+    ],
+  }),
+}));
+
+describe('<BlockHistory />', () => {
+  it('renders paginated block list', () => {
+    render(<BlockHistory />);
+    expect(screen.getByRole('heading', { name: /block history/i })).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+});

--- a/ui/src/__tests__/dashboard.test.tsx
+++ b/ui/src/__tests__/dashboard.test.tsx
@@ -22,6 +22,10 @@ vi.mock('../components/BlockList', () => ({
   __esModule: true,
   default: () => <div data-testid="block-list" />,
 }));
+vi.mock('../components/BlockHistory', () => ({
+  __esModule: true,
+  default: () => <div data-testid="block-history" />,
+}));
 vi.mock('../components/RawTxSubmit', () => ({
   __esModule: true,
   default: () => <div data-testid="rawtx" />,
@@ -50,5 +54,6 @@ describe('<Dashboard />', () => {
     expect(screen.getByText('7')).toBeInTheDocument();
     expect(screen.getByTestId('wallet-view')).toBeInTheDocument();
     expect(screen.getByTestId('block-list')).toBeInTheDocument();
+    expect(screen.getByTestId('block-history')).toBeInTheDocument();
   });
 });

--- a/ui/src/components/BlockHistory.tsx
+++ b/ui/src/components/BlockHistory.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+import { get } from '../api/rest';
+import type { Block } from '../types/block';
+
+export default function BlockHistory() {
+  // current page index and gap between pages
+  const [page, setPage] = useState(0);
+  const [gap, setGap] = useState(5);
+  const { data } = useSWR<Block[]>(
+    // fetch paginated blocks from the backend
+    `/chain/page?page=${page}&size=${gap}`,
+    (path: string) => get<Block[]>(path),
+  );
+
+  // keep UI empty until first page loads
+  if (!data) return null;
+
+  return (
+    <section aria-label="block history" className="space-y-2">
+      <h2 className="text-lg font-semibold">Block History</h2>
+      <div className="space-x-2">
+        <button
+          onClick={() => setPage(p => Math.max(0, p - 1))}
+          disabled={page === 0}
+          className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-50"
+        >
+          Newer
+        </button>
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={data.length < gap}
+          className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-50"
+        >
+          Older
+        </button>
+        <input
+          type="number"
+          className="w-16 rounded border px-1 py-0.5"
+          value={gap}
+          onChange={e => setGap(Number(e.target.value))}
+          min={1}
+        />
+      </div>
+      <ul className="space-y-1">
+        {data
+          .slice()
+          .reverse()
+          .map(b => (
+            <li key={b.hashHex} className="rounded bg-white p-2 shadow">
+              <details>
+                <summary className="cursor-pointer">
+                  <span className="font-mono">#{b.height}</span>{' '}
+                  <span className="font-mono">{b.hashHex.slice(0, 16)}…</span>
+                </summary>
+                {b.txList && (
+                  <pre className="mt-2 overflow-x-auto text-xs">
+                    {JSON.stringify(b.txList, null, 2)}
+                  </pre>
+                )}
+              </details>
+            </li>
+          ))}
+      </ul>
+    </section>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import type { Block } from '../types/block';   // ❶ Type-only-Import
 import { StatCard } from '../components/StatCard';
 import WalletView from '../components/WalletView';
 import BlockList from '../components/BlockList';
+import BlockHistory from '../components/BlockHistory';
 import RawTxSubmit from '../components/RawTxSubmit';
 
 export default function Dashboard() {
@@ -23,6 +24,7 @@ export default function Dashboard() {
           <StatCard label="Latest hash" value={tip ? tip.hashHex.slice(0, 16) : '…'} />
         </div>
         <BlockList />
+        <BlockHistory />
       </section>
       <div className="md:col-span-2 space-y-6">
         <WalletView />

--- a/ui/src/types/block.ts
+++ b/ui/src/types/block.ts
@@ -2,4 +2,5 @@ export interface Block {
   height: number;
   compactDifficultyBits: number;
   hashHex: string;
+  txList?: unknown[];
 }


### PR DESCRIPTION
## Summary
- expose paginated blocks via `/api/chain/page`
- add wallet transaction history endpoint
- add BlockHistory component with paging controls
- document tests with brief comments

## Testing
- `./gradlew test`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c5216e8f48326b57eea18a45d5404