### PR TITLE
Enable persistent peer connections

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/discovery/PeerDiscoveryService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/discovery/PeerDiscoveryService.java
@@ -34,6 +34,7 @@ public class PeerDiscoveryService {
             Peer p = Peer.fromString(addr);
             registry.add(p);
             routing.putIfAbsent(p.toString(), p);
+            client.connect(p);
             client.send(p, new FindNodeDto(props.getId()));
         });
     }
@@ -66,6 +67,7 @@ public class PeerDiscoveryService {
                     .forEach(p -> {
                         routing.putIfAbsent(p.toString(), p);
                         registry.add(p);
+                        client.connect(p);
                     });
         }
     }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerClient.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerClient.java
@@ -2,6 +2,8 @@ package de.flashyotter.blockchain_node.p2p;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.flashyotter.blockchain_node.dto.P2PMessageDto;
+import de.flashyotter.blockchain_node.dto.HandshakeDto;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -21,8 +24,12 @@ public class PeerClient {
 
     private final ObjectMapper                mapper;
     private final ReactorNettyWebSocketClient wsClient;
+    private final NodeProperties              props;
 
     private final ConcurrentHashMap<Peer, CircuitBreaker> breakers =
+            new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<Peer, reactor.core.publisher.Sinks.Many<String>> channels =
             new ConcurrentHashMap<>();
 
     private CircuitBreaker cb(Peer p) {
@@ -30,18 +37,43 @@ public class PeerClient {
                 __ -> CircuitBreaker.ofDefaults("peer-" + p.toString()));
     }
 
+    /** Establish a persistent connection to the given peer. */
+    public void connect(Peer peer) {
+        ensureChannel(peer);             // lazy creation starts connection
+    }
+
     @SneakyThrows
     public void send(Peer peer, P2PMessageDto msg) {
-
+        var sink = ensureChannel(peer);
         String json = mapper.writeValueAsString(msg);
-
-        Mono<Void> pipeline = Mono.defer(() ->
-                wsClient.execute(URI.create(peer.wsUrl()),
-                                 s -> s.send(Mono.just(s.textMessage(json))).then()))
-            .transformDeferred(CircuitBreakerOperator.of(cb(peer)))
-            .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
-            .doOnError(e -> log.warn("❌  send to {} failed: {}", peer, e.toString()));
-
-        pipeline.subscribe();         // fire-and-forget
+        sink.tryEmitNext(json);
     }
+
+    /* ----------------------------------------------------------- */
+    /* internal helpers                                             */
+    /* ----------------------------------------------------------- */
+
+    private reactor.core.publisher.Sinks.Many<String> ensureChannel(Peer peer) {
+        return channels.computeIfAbsent(peer, p -> {
+            var sink = reactor.core.publisher.Sinks.many().unicast().<String>onBackpressureBuffer();
+
+            Flux<Void> pipeline = Flux.defer(() ->
+                    wsClient.execute(URI.create(p.wsUrl()), session -> {
+                        HandshakeDto hello = new HandshakeDto(props.getId(), "0.4.0");
+                        Mono<Void> hs = session.send(Mono.just(session.textMessage(toJson(hello))));
+                        Mono<Void> out = session.send(sink.asFlux().map(session::textMessage));
+                        return hs.then(out.then());
+                    }))
+                .transformDeferred(CircuitBreakerOperator.of(cb(p)))
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(5)))
+                .doOnError(e -> log.warn("❌  conn {} failed: {}", p, e.getMessage()))
+                .doFinally(sig -> channels.remove(p));
+
+            pipeline.subscribe();
+            return sink;
+        });
+    }
+
+    @SneakyThrows
+    private String toJson(Object o) { return mapper.writeValueAsString(o); }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -2,6 +2,7 @@ package de.flashyotter.blockchain_node.service;
 
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.p2p.Peer;
+import de.flashyotter.blockchain_node.p2p.PeerClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import jakarta.annotation.PostConstruct;          // ← switched to Jakarta namespace
@@ -19,12 +20,15 @@ public class PeerService {
     private final PeerRegistry         registry;
     private final P2PBroadcastService  broadcaster;
     private final PeerDiscoveryService discovery;
+    private final PeerClient           client;
 
     @PostConstruct
     public void init() {
         props.getPeers().forEach(addr -> {
             var sp = addr.split(":");
-            registry.add(new Peer(sp[0], Integer.parseInt(sp[1])));
+            Peer p = new Peer(sp[0], Integer.parseInt(sp[1]));
+            registry.add(p);
+            client.connect(p);
         });
 
         registry.all()

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
@@ -15,6 +15,7 @@ import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
 import de.flashyotter.blockchain_node.service.PeerService;
 import de.flashyotter.blockchain_node.service.SyncService;
+import de.flashyotter.blockchain_node.p2p.PeerClient;
 import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
 import reactor.core.publisher.Flux;
 
@@ -32,6 +33,9 @@ class PeerServiceTest {
     @Mock
     private PeerDiscoveryService discovery;
 
+    @Mock
+    private PeerClient client;
+
     private PeerService svc;
     private NodeProperties props;
 
@@ -41,7 +45,7 @@ class PeerServiceTest {
         props = new NodeProperties();
         // set two peers
         props.setPeers(java.util.List.of("one:100", "two:200"));
-        svc = new PeerService(props, sync, reg, broad, discovery);
+        svc = new PeerService(props, sync, reg, broad, discovery, client);
     }
 
     @Test
@@ -54,6 +58,10 @@ class PeerServiceTest {
         // registry.add for each peer string
         verify(reg).add(new Peer("one", 100));
         verify(reg).add(new Peer("two", 200));
+
+        // connect called for each peer
+        verify(client).connect(new Peer("one", 100));
+        verify(client).connect(new Peer("two", 200));
 
         // followPeer called for each wsUrl
         verify(sync).followPeer("ws://one:100/ws");

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/PeerDiscoveryServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/PeerDiscoveryServiceTest.java
@@ -26,5 +26,6 @@ class PeerDiscoveryServiceTest {
 
         assertTrue(registry.all().contains(new Peer("host1",1111)), "peer added");
         assertEquals(1, registry.pending().size(), "pending queue populated");
+        verify(client).connect(new Peer("host1", 1111));
     }
 }


### PR DESCRIPTION
## Summary
- maintain long-lived WebSocket channels in `PeerClient`
- connect to peers on startup via `PeerService` and `PeerDiscoveryService`
- update unit tests for new connection behaviour

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68619396bacc83268ca993352479de4b