### PR TITLE
Refactor peer discovery bootstrap

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/discovery/PeerDiscoveryService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/discovery/PeerDiscoveryService.java
@@ -30,11 +30,10 @@ public class PeerDiscoveryService {
 
     @PostConstruct
     void bootstrap() {
+        // Seed the routing table with peers configured in application
         props.getPeers().forEach(addr -> {
             Peer p = Peer.fromString(addr);
-            registry.add(p);
             routing.putIfAbsent(p.toString(), p);
-            client.send(p, new FindNodeDto(props.getId()));
         });
     }
 


### PR DESCRIPTION
## Summary
- trim responsibilities of `PeerDiscoveryService.bootstrap`
- keep seed peer connection logic inside `PeerService`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68619d7414c88326bf8c6a18164fd01a