### PR TITLE
Add persistent peer connections

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/ConnectionManager.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/ConnectionManager.java
@@ -1,0 +1,86 @@
+package de.flashyotter.blockchain_node.p2p;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.dto.HandshakeDto;
+import de.flashyotter.blockchain_node.dto.P2PMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.util.retry.Retry;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Maintains one persistent WebSocket connection per {@link Peer}.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ConnectionManager {
+
+    private final ReactorNettyWebSocketClient wsClient;
+    private final ObjectMapper mapper;
+    private final NodeProperties props;
+
+    /** Holder object returned by {@link #connectAndSink(Peer)}. */
+    public record Conn(Sinks.Many<String> outbound, Flux<P2PMessageDto> inbound) {}
+
+    private final ConcurrentHashMap<Peer, Conn> connections = new ConcurrentHashMap<>();
+
+    /** Establish or reuse a persistent connection to the given peer. */
+    public Conn connectAndSink(Peer peer) {
+        return connections.computeIfAbsent(peer, this::createConnection);
+    }
+
+    /* --------------------------------------------------------------- */
+    /* internal helpers                                                 */
+    /* --------------------------------------------------------------- */
+
+    private Conn createConnection(Peer peer) {
+        Sinks.Many<String> out = Sinks.many().multicast().onBackpressureBuffer();
+        Flux<P2PMessageDto> inbound = maintainConnection(peer, out).share();
+        return new Conn(out, inbound);
+    }
+
+    private Flux<P2PMessageDto> maintainConnection(Peer peer, Sinks.Many<String> out) {
+        Sinks.Many<P2PMessageDto> inSink = Sinks.many().multicast().onBackpressureBuffer();
+
+        Mono<Void> pipeline = Mono.defer(() ->
+                wsClient.execute(URI.create(peer.wsUrl()), session -> {
+                    String hello = toJson(new HandshakeDto(props.getId(), "0.4.0"));
+                    Flux<WebSocketMessage> sendFlux = Flux.concat(
+                            Mono.just(hello),
+                            out.asFlux()
+                    ).map(session::textMessage);
+
+                    Mono<Void> send = session.send(sendFlux);
+                    Mono<Void> recv = session.receive()
+                            .map(WebSocketMessage::getPayloadAsText)
+                            .map(this::toDto)
+                            .doOnNext(inSink::tryEmitNext)
+                            .then();
+                    return send.then(recv);
+                })
+        )
+        .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(5)))
+        .doOnError(e -> log.warn("❌  connection {} – {}", peer, e.getMessage()));
+
+        pipeline.subscribe();
+
+        return inSink.asFlux();
+    }
+
+    @SneakyThrows
+    private String toJson(Object o) { return mapper.writeValueAsString(o); }
+    @SneakyThrows
+    private P2PMessageDto toDto(String j) { return mapper.readValue(j, P2PMessageDto.class); }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerClient.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerClient.java
@@ -2,46 +2,29 @@ package de.flashyotter.blockchain_node.p2p;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.flashyotter.blockchain_node.dto.P2PMessageDto;
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
-import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
-
-import java.net.URI;
-import java.time.Duration;
-import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Sinks;
 
 @Component @RequiredArgsConstructor @Slf4j
 public class PeerClient {
 
     private final ObjectMapper                mapper;
-    private final ReactorNettyWebSocketClient wsClient;
-
-    private final ConcurrentHashMap<Peer, CircuitBreaker> breakers =
-            new ConcurrentHashMap<>();
-
-    private CircuitBreaker cb(Peer p) {
-        return breakers.computeIfAbsent(p,
-                __ -> CircuitBreaker.ofDefaults("peer-" + p.toString()));
-    }
+    private final ConnectionManager           connections;
 
     @SneakyThrows
     public void send(Peer peer, P2PMessageDto msg) {
 
         String json = mapper.writeValueAsString(msg);
 
-        Mono<Void> pipeline = Mono.defer(() ->
-                wsClient.execute(URI.create(peer.wsUrl()),
-                                 s -> s.send(Mono.just(s.textMessage(json))).then()))
-            .transformDeferred(CircuitBreakerOperator.of(cb(peer)))
-            .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
-            .doOnError(e -> log.warn("❌  send to {} failed: {}", peer, e.toString()));
-
-        pipeline.subscribe();         // fire-and-forget
+        Sinks.EmitResult result =
+                connections.connectAndSink(peer)
+                           .outbound()
+                           .tryEmitNext(json);
+        if (result.isFailure()) {
+            log.warn("❌  send to {} failed: {}", peer, result);
+        }
     }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -20,7 +20,7 @@ public class DiscoveryLoop {
             while (true) {
                 try {
                     Peer p = reg.pending().take();
-                    sync.followPeer(p.wsUrl()).subscribe();
+                    sync.followPeer(p).subscribe();
                 } catch (InterruptedException ignored) { }
             }
         });

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -28,7 +28,7 @@ public class PeerService {
         });
 
         registry.all()
-                .forEach(p -> syncService.followPeer(p.wsUrl()).subscribe());
+                .forEach(p -> syncService.followPeer(p).subscribe());
 
         broadcaster.broadcastPeerList();
         // trigger discovery after initial connections

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
@@ -1,75 +1,45 @@
 package de.flashyotter.blockchain_node.service;
 
-import java.net.URI;
-import java.time.Duration;
-
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import blockchain.core.consensus.Chain;
 import blockchain.core.model.Block;
 import blockchain.core.model.Transaction;
-import de.flashyotter.blockchain_node.dto.HandshakeDto;
 import de.flashyotter.blockchain_node.dto.NewBlockDto;
 import de.flashyotter.blockchain_node.dto.NewTxDto;
-import de.flashyotter.blockchain_node.dto.P2PMessageDto;
-import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.p2p.ConnectionManager;
+import de.flashyotter.blockchain_node.p2p.Peer;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 @Service
 @RequiredArgsConstructor @Slf4j
 public class SyncService {
 
-    private final Chain                       chain;
-    private final NodeService                 node;
-    private final ObjectMapper                mapper;
-    private final ReactorNettyWebSocketClient wsClient;
-    private final NodeProperties              props;
+    private final NodeService       node;
+    private final ObjectMapper      mapper;
+    private final ConnectionManager manager;
 
     /** Dauerhafte Block-Synchro mit automatischem Re-Connect */
-    public Flux<Void> followPeer(String wsUrl) {
+    public Flux<Void> followPeer(Peer peer) {
 
-        return Flux.defer(() ->
-                wsClient.execute(URI.create(wsUrl),
-                                 s -> {
-                                     // send our handshake first
-                                     HandshakeDto hello = new HandshakeDto(
-                                             props.getId(),
-                                             "0.4.0");
-                                     Mono<Void> snd = s.send(Mono.just(
-                                             s.textMessage(toJson(hello))));
-
-                                     Mono<Void> rcv = s.receive()
-                                             .map(fr -> fr.getPayloadAsText())
-                                             .map(this::toDto)
-                                             .handle((dto, sink) -> {
-                                                 if (dto instanceof NewBlockDto nb) {
-                                                     sink.next(toBlock(nb));
-                                                 }
-                                                 if (dto instanceof NewTxDto nt) {
-                                                     node.acceptExternalTx(toTx(nt));
-                                                 }
-                                             })
-                                             .cast(Block.class)
-                                             .doOnNext(node::acceptExternalBlock)
-                                             .then();
-
-                                     return snd.then(rcv);
-                                 }))
-            .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(5)))
-            .doOnError(e -> log.warn("sync({}) – {}", wsUrl, e.getMessage()));
+        return manager.connectAndSink(peer).inbound()
+            .flatMap(dto -> {
+                if (dto instanceof NewBlockDto nb) {
+                    node.acceptExternalBlock(toBlock(nb));
+                }
+                if (dto instanceof NewTxDto nt) {
+                    node.acceptExternalTx(toTx(nt));
+                }
+                return Mono.empty();
+            });
     }
 
     /* helper */
-    @SneakyThrows private String       toJson(Object o){ return mapper.writeValueAsString(o); }
-    @SneakyThrows private P2PMessageDto toDto(String j){ return mapper.readValue(j, P2PMessageDto.class); }
     @SneakyThrows private Block         toBlock(NewBlockDto d){ return mapper.readValue(d.rawBlockJson(), Block.class); }
     @SneakyThrows private Transaction   toTx(NewTxDto d){ return mapper.readValue(d.rawTxJson(), Transaction.class); }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
@@ -1,6 +1,6 @@
 package de.flashyotter.blockchain_node.p2p;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +11,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.p2p.Peer;
 import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
 import de.flashyotter.blockchain_node.service.PeerService;
@@ -47,7 +48,7 @@ class PeerServiceTest {
     @Test
     void initAddsAndSyncsAndBroadcasts() {
         // stub sync to return an empty flux
-        when(sync.followPeer(anyString())).thenReturn(Flux.empty());
+        when(sync.followPeer(any())).thenReturn(Flux.empty());
 
         svc.init();
 
@@ -55,9 +56,9 @@ class PeerServiceTest {
         verify(reg).add(new Peer("one", 100));
         verify(reg).add(new Peer("two", 200));
 
-        // followPeer called for each wsUrl
-        verify(sync).followPeer("ws://one:100/ws");
-        verify(sync).followPeer("ws://two:200/ws");
+        // followPeer called for each peer
+        verify(sync).followPeer(new Peer("one", 100));
+        verify(sync).followPeer(new Peer("two", 200));
 
         // broadcastPeerList at end
         verify(broad).broadcastPeerList();


### PR DESCRIPTION
## Summary
- manage long-lived WebSocket per peer via new `ConnectionManager`
- delegate `PeerClient` to use this manager
- update `SyncService` to consume messages from the manager
- adjust `PeerService` and `DiscoveryLoop` for new API
- update unit tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6861aa48599c832695c3372e58a00c49