### PR TITLE
Add server-side connection support

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
@@ -8,6 +8,7 @@ import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
+import de.flashyotter.blockchain_node.p2p.ConnectionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ public class PeerServer extends TextWebSocketHandler {
     private final P2PBroadcastService broadcast;
     private final NodeProperties      props;
     private final PeerDiscoveryService discovery;
+    private final ConnectionManager   connectionManager;
 
     private static final String PROTOCOL_VER = "0.4.0";
 
@@ -36,6 +38,10 @@ public class PeerServer extends TextWebSocketHandler {
         // send our handshake immediately
         HandshakeDto hello = new HandshakeDto(props.getId(), PROTOCOL_VER);
         session.sendMessage(new TextMessage(mapper.writeValueAsString(hello)));
+
+        java.net.InetSocketAddress addr = (java.net.InetSocketAddress) session.getRemoteAddress();
+        Peer peer = new Peer(addr.getHostString(), addr.getPort());
+        connectionManager.registerServerSession(peer, session);
     }
 
     @Override
@@ -43,67 +49,8 @@ public class PeerServer extends TextWebSocketHandler {
     public void handleTextMessage(WebSocketSession sess, TextMessage msg) {
 
         P2PMessageDto dto = mapper.readValue(msg.getPayload(), P2PMessageDto.class);
-
-        /* ------------------------------------------------ handshake ---- */
-        if (dto instanceof HandshakeDto hs) {
-            if (!PROTOCOL_VER.split("\\.")[0]
-                             .equals(hs.protocolVersion().split("\\.")[0])) {
-                log.warn("⚠️  incompatible peer {}; disconnecting", hs);
-                sess.close();
-                return;
-            }
-            // register the peer id and send our peer list
-            java.net.InetSocketAddress addr = (java.net.InetSocketAddress) sess.getRemoteAddress();
-            Peer remote = new Peer(addr.getHostString(), addr.getPort());
-            discovery.onMessage(hs, remote);
-            broadcast.broadcastPeerList();
-            return;                                     // nothing further
-        }
-
-        /* ------------------------------------------------ transactions - */
-        if (dto instanceof NewTxDto nt) {
-            var tx = mapper.readValue(nt.rawTxJson(),
-                                       blockchain.core.model.Transaction.class);
-            node.acceptExternalTx(tx);
-            broadcast.broadcastTx(nt, null);
-            return;
-        }
-
-        /* ------------------------------------------------ blocks -------- */
-        if (dto instanceof NewBlockDto nb) {
-            var blk = mapper.readValue(nb.rawBlockJson(),
-                                        blockchain.core.model.Block.class);
-            node.acceptExternalBlock(blk);
-            broadcast.broadcastBlock(nb, null);
-            return;
-        }
-
-        /* ------------------------------------------------ range sync ---- */
-        if (dto instanceof GetBlocksDto gb) {
-            List<blockchain.core.model.Block> blocks =
-                    node.blocksFromHeight(gb.fromHeight());
-            List<String> raws = blocks.stream()
-                                      .map(blockchain.core.serialization.JsonUtils::toJson)
-                                      .toList();
-            sess.sendMessage(new TextMessage(
-                    mapper.writeValueAsString(new BlocksDto(raws))));
-            return;
-        }
-
-        /* ------------------------------------------------ discovery ----- */
-        if (dto instanceof PeerListDto pl) {
-            registry.addAll(pl.peers().stream().map(Peer::fromString).toList());
-            return;
-        }
-
-        // delegate discovery-related messages
-        if (dto instanceof de.flashyotter.blockchain_node.discovery.PingDto
-            || dto instanceof de.flashyotter.blockchain_node.discovery.PongDto
-            || dto instanceof de.flashyotter.blockchain_node.discovery.FindNodeDto
-            || dto instanceof de.flashyotter.blockchain_node.discovery.NodesDto) {
-            java.net.InetSocketAddress a = (java.net.InetSocketAddress) sess.getRemoteAddress();
-            discovery.onMessage(dto, new Peer(a.getHostString(), a.getPort()));
-            return;
-        }
+        java.net.InetSocketAddress addr = (java.net.InetSocketAddress) sess.getRemoteAddress();
+        Peer peer = new Peer(addr.getHostString(), addr.getPort());
+        connectionManager.emitInbound(peer, dto);
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerClientTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerClientTest.java
@@ -28,7 +28,7 @@ class PeerClientTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         sink = Sinks.many().unicast().onBackpressureBuffer();
-        when(manager.connectAndSink(any())).thenReturn(new ConnectionManager.Conn(sink, Flux.never()));
+        when(manager.connectAndSink(any())).thenReturn(new ConnectionManager.Conn(sink, Sinks.many().unicast().onBackpressureBuffer(), Flux.never()));
         client = new PeerClient(mapper, manager);
     }
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
@@ -1,37 +1,30 @@
 package de.flashyotter.blockchain_node.p2p;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
-import java.util.List;
+import java.net.InetSocketAddress;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.ArgumentCaptor;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import de.flashyotter.blockchain_node.dto.BlocksDto;
-import de.flashyotter.blockchain_node.dto.GetBlocksDto;
-import de.flashyotter.blockchain_node.dto.NewBlockDto;
-import de.flashyotter.blockchain_node.dto.NewTxDto;
-import de.flashyotter.blockchain_node.dto.P2PMessageDto;
-import de.flashyotter.blockchain_node.dto.PeerListDto;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
-import de.flashyotter.blockchain_node.config.NodeProperties;
-import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 class PeerServerTest {
 
@@ -42,93 +35,58 @@ class PeerServerTest {
     @Mock NodeProperties props;
     @Mock PeerDiscoveryService discovery;
     @Mock WebSocketSession session;
-
-    @Captor ArgumentCaptor<TextMessage> messageCaptor;
-
-    PeerServer peerServer;
+    @Mock reactor.netty.http.client.HttpClient httpClient;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery);
+        try { when(mapper.writeValueAsString(any())).thenReturn("{}"); } catch (Exception ignored) {}
     }
 
     @Test
-    void handleNewTxDto_forwardsToNodeAndBroadcasts() throws Exception {
-        // given
-        String rawTxJson = "{\"dummy\":\"tx\"}";
-        NewTxDto dto = new NewTxDto(rawTxJson);
+    void afterConnectionEstablished_registersSession() throws Exception {
+        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(props.getId()).thenReturn("n1");
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 1));
 
-        when(mapper.readValue(anyString(), eq(P2PMessageDto.class))).thenReturn(dto);
-        when(mapper.readValue(rawTxJson, blockchain.core.model.Transaction.class))
-            .thenReturn(new blockchain.core.model.Transaction());
+        peerServer.afterConnectionEstablished(session);
 
-        // when
-        peerServer.handleTextMessage(
-            session,
-            new TextMessage("{\"type\":\"NewTxDto\",\"rawTxJson\":" + rawTxJson + "}")
-        );
-
-        // then
-        verify(nodeService).acceptExternalTx(any());
-        verify(broadcastService).broadcastTx(eq(dto), isNull());
+        verify(manager).registerServerSession(new Peer("host", 1), session);
+        verify(session).sendMessage(any(TextMessage.class));
     }
 
     @Test
-    void handleNewBlockDto_forwardsToNodeAndBroadcasts() throws Exception {
-        String rawBlockJson = "{\"dummy\":\"block\"}";
-        NewBlockDto dto = new NewBlockDto(rawBlockJson);
+    void outboundMessagesAreSentThroughSession() throws Exception {
+        var wsClient = org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class);
+        ConnectionManager manager = new ConnectionManager(wsClient, mapper, props);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(props.getId()).thenReturn("n1");
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 2));
+        when(session.isOpen()).thenReturn(true, false);
 
-        when(mapper.readValue(anyString(), eq(P2PMessageDto.class))).thenReturn(dto);
-        when(mapper.readValue(rawBlockJson, blockchain.core.model.Block.class))
-            .thenReturn(new blockchain.core.model.Block(0, "0".repeat(64), List.of(), 0));
+        peerServer.afterConnectionEstablished(session);
+        ConnectionManager.Conn c = manager.connectAndSink(new Peer("host", 2));
+        c.outbound().tryEmitNext("{\"hello\":1}");
 
-        peerServer.handleTextMessage(
-            session,
-            new TextMessage("{\"type\":\"NewBlockDto\",\"rawBlockJson\":" + rawBlockJson + "}")
+        Awaitility.await().untilAsserted(() ->
+            verify(session, times(2)).sendMessage(any(TextMessage.class))
         );
-
-        verify(nodeService).acceptExternalBlock(any());
-        verify(broadcastService).broadcastBlock(eq(dto), isNull());
     }
 
     @Test
-    void handleGetBlocksDto_returnsBlocksList() throws Exception {
-        // prepare
-        GetBlocksDto req = new GetBlocksDto(5);
-        List<blockchain.core.model.Block> blocks = List.of(
-            new blockchain.core.model.Block(5, "0".repeat(64), List.of(), 0)
-        );
+    void closingSessionRemovesConnection() throws Exception {
+        var wsClient = org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class);
+        ConnectionManager manager = new ConnectionManager(wsClient, mapper, props);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(props.getId()).thenReturn("n1");
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 3));
+        when(session.isOpen()).thenReturn(true, false);
 
-        when(mapper.readValue(anyString(), eq(P2PMessageDto.class))).thenReturn(req);
-        when(nodeService.blocksFromHeight(5)).thenReturn(blocks);
-        when(mapper.writeValueAsString(any(BlocksDto.class)))
-             .thenReturn("{\"rawBlocks\":[\"someJson\"]}");
+        peerServer.afterConnectionEstablished(session);
+        Peer peer = new Peer("host", 3);
+        ConnectionManager.Conn first = manager.connectAndSink(peer);
 
-        peerServer.handleTextMessage(
-            session,
-            new TextMessage("{\"type\":\"GetBlocksDto\",\"fromHeight\":5}")
-        );
-
-        verify(session).sendMessage(messageCaptor.capture());
-        String sent = messageCaptor.getValue().getPayload();
-        assert sent.contains("\"rawBlocks\"");
-    }
-
-    @Test
-    void handlePeerListDto_addsToRegistry() throws Exception {
-        PeerListDto dto = new PeerListDto(List.of("host1:1234", "host2:5678"));
-
-        when(mapper.readValue(anyString(), eq(P2PMessageDto.class))).thenReturn(dto);
-
-        peerServer.handleTextMessage(
-            session,
-            new TextMessage("{\"type\":\"PeerListDto\",\"peers\":[\"host1:1234\",\"host2:5678\"]}")
-        );
-
-        // registry.addAll should be called with exactly two Peer instances
-        verify(registry).addAll(argThat(iter -> {
-            return ((java.util.Collection<?>) iter).size() == 2;
-       }));
+        Awaitility.await().until(() -> !manager.connectAndSink(peer).equals(first));
     }
 }


### PR DESCRIPTION
## Summary
- extend `ConnectionManager` to register incoming WebSocket sessions
- connect `PeerServer` to new manager
- route server messages through the manager
- update networking tests for new behaviour

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6861b0fe0a20832690af3ae41c0ee955