### PR TITLE
Handle P2P discovery messages

### DIFF
--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
@@ -19,7 +19,14 @@ import org.springframework.web.socket.WebSocketSession;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.dto.HandshakeDto;
+import de.flashyotter.blockchain_node.dto.P2PMessageDto;
+import de.flashyotter.blockchain_node.dto.PeerListDto;
+import de.flashyotter.blockchain_node.discovery.FindNodeDto;
 import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
+import de.flashyotter.blockchain_node.discovery.PingDto;
+import de.flashyotter.blockchain_node.discovery.PongDto;
+import de.flashyotter.blockchain_node.discovery.NodesDto;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
@@ -88,5 +95,52 @@ class PeerServerTest {
         ConnectionManager.Conn first = manager.connectAndSink(peer);
 
         Awaitility.await().until(() -> !manager.connectAndSink(peer).equals(first));
+    }
+
+    @Test
+    void handleHandshake_addsPeerAndBroadcasts() throws Exception {
+        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 9));
+        HandshakeDto dto = new HandshakeDto("n2", "0.4.0");
+        when(mapper.readValue("{}", P2PMessageDto.class)).thenReturn(dto);
+
+        peerServer.handleTextMessage(session, new TextMessage("{}"));
+
+        Peer peer = new Peer("host", 9);
+        verify(registry).add(peer);
+        verify(broadcastService).broadcastPeerList();
+        verify(discovery).onMessage(dto, peer);
+    }
+
+    @Test
+    void handlePeerList_addsPeers() throws Exception {
+        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("src", 4));
+        PeerListDto dto = new PeerListDto(java.util.List.of("h1:1", "h2:2"));
+        when(mapper.readValue("json", P2PMessageDto.class)).thenReturn(dto);
+
+        peerServer.handleTextMessage(session, new TextMessage("json"));
+
+        java.util.List<Peer> expected = java.util.List.of(new Peer("h1",1), new Peer("h2",2));
+        verify(registry).addAll(expected);
+    }
+
+    @Test
+    void handleDiscoveryMessages_delegateToService() throws Exception {
+        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+        PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager);
+        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("h", 5));
+        when(mapper.readValue(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq(P2PMessageDto.class)))
+            .thenReturn(new PingDto("a"), new PongDto("b"), new FindNodeDto("c"), new NodesDto(java.util.List.of()));
+
+        peerServer.handleTextMessage(session, new TextMessage("1"));
+        peerServer.handleTextMessage(session, new TextMessage("2"));
+        peerServer.handleTextMessage(session, new TextMessage("3"));
+        peerServer.handleTextMessage(session, new TextMessage("4"));
+
+        Peer peer = new Peer("h", 5);
+        verify(discovery, times(4)).onMessage(any(), org.mockito.ArgumentMatchers.eq(peer));
     }
 }


### PR DESCRIPTION
## Summary
- handle discovery DTOs in `PeerServer`
- add tests for handshake, peer list and discovery message handling

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_6861bdd07e288326bdb069430c7f069f