### PR TITLE
Handle inbound peer sync

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerRegistry.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerRegistry.java
@@ -19,9 +19,16 @@ public class PeerRegistry {
          return peers; 
     }
 
-    public void add(Peer p) { 
-        if (peers.add(p)) pending.add(p);          // mark for dial
-     }
+    /**
+     * Add a peer to the registry.
+     *
+     * @return {@code true} if the peer was not known yet
+     */
+    public boolean add(Peer p) {
+        boolean fresh = peers.add(p);
+        if (fresh) pending.add(p);          // mark for dial
+        return fresh;
+    }
 
     /* dial queue consumed by discovery loop */
     private final java.util.concurrent.BlockingQueue<Peer> pending =


### PR DESCRIPTION
## Summary
- return `boolean` from `PeerRegistry.add` to detect new peers
- inject `SyncService` into `PeerServer`
- follow peers immediately upon handshake
- update tests for new constructor and behavior

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6861c4e57bdc83268c5106a375007972