### PR TITLE
Switch to reactive WebSocket handler

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/WebSocketConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/WebSocketConfig.java
@@ -1,13 +1,14 @@
 // blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/WebSocketConfig.java
 package de.flashyotter.blockchain_node.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
-import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 import de.flashyotter.blockchain_node.p2p.PeerServer;
@@ -27,10 +28,8 @@ import lombok.RequiredArgsConstructor;
  */
 @Configuration
 @EnableWebSocketMessageBroker   // für STOMP/SockJS
-@EnableWebSocket                // für raw WebSocketHandler
 @RequiredArgsConstructor
-public class WebSocketConfig 
-     implements WebSocketMessageBrokerConfigurer, WebSocketConfigurer {
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final PeerServer peerServer;
 
@@ -45,9 +44,18 @@ public class WebSocketConfig
         reg.setApplicationDestinationPrefixes("/app");
     }
 
-    @Override
-    public void registerWebSocketHandlers(WebSocketHandlerRegistry reg) {
-        reg.addHandler(peerServer, "/ws")
-           .setAllowedOriginPatterns("*");
+    @Bean
+    public SimpleUrlHandlerMapping wsHandlerMapping() {
+        java.util.Map<String, WebSocketHandler> map = new java.util.HashMap<>();
+        map.put("/ws", peerServer);
+        SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+        mapping.setUrlMap(map);
+        mapping.setOrder(-1);
+        return mapping;
+    }
+
+    @Bean
+    public WebSocketHandlerAdapter wsAdapter() {
+        return new WebSocketHandlerAdapter();
     }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
@@ -1,31 +1,32 @@
-// blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
 package de.flashyotter.blockchain_node.p2p;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.flashyotter.blockchain_node.dto.*;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.discovery.FindNodeDto;
 import de.flashyotter.blockchain_node.discovery.NodesDto;
+import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
 import de.flashyotter.blockchain_node.discovery.PingDto;
 import de.flashyotter.blockchain_node.discovery.PongDto;
+import de.flashyotter.blockchain_node.dto.*;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
 import de.flashyotter.blockchain_node.service.SyncService;
-import de.flashyotter.blockchain_node.config.NodeProperties;
-import de.flashyotter.blockchain_node.discovery.PeerDiscoveryService;
-import de.flashyotter.blockchain_node.p2p.ConnectionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
-@Component @RequiredArgsConstructor @Slf4j
-public class PeerServer extends TextWebSocketHandler {
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PeerServer implements WebSocketHandler {
 
     private final ObjectMapper        mapper;
     private final NodeService         node;
@@ -40,44 +41,38 @@ public class PeerServer extends TextWebSocketHandler {
 
     @Override
     @SneakyThrows
-    public void afterConnectionEstablished(WebSocketSession session) {
-        // send our handshake immediately
+    public Mono<Void> handle(WebSocketSession session) {
         HandshakeDto hello = new HandshakeDto(props.getId(), PROTOCOL_VER);
-        session.sendMessage(new TextMessage(mapper.writeValueAsString(hello)));
-
-        java.net.InetSocketAddress addr = (java.net.InetSocketAddress) session.getRemoteAddress();
+        InetSocketAddress addr = session.getHandshakeInfo().getRemoteAddress();
         Peer peer = new Peer(addr.getHostString(), addr.getPort());
-        connectionManager.registerServerSession(peer, session);
-    }
 
-    @Override
-    @SneakyThrows
-    public void handleTextMessage(WebSocketSession sess, TextMessage msg) {
+        ConnectionManager.Conn conn = connectionManager.registerServerSession(peer, session);
 
-        P2PMessageDto dto = mapper.readValue(msg.getPayload(), P2PMessageDto.class);
-        java.net.InetSocketAddress addr = (java.net.InetSocketAddress) sess.getRemoteAddress();
-        Peer peer = new Peer(addr.getHostString(), addr.getPort());
-        connectionManager.emitInbound(peer, dto);
-
-        if (dto instanceof HandshakeDto) {
-            boolean fresh = registry.add(peer);
-            broadcast.broadcastPeerList();
-            discovery.onMessage(dto, peer);
-            if (fresh) {
-                syncService.followPeer(peer).subscribe();
+        conn.inbound().subscribe(dto -> {
+            if (dto instanceof HandshakeDto) {
+                boolean fresh = registry.add(peer);
+                broadcast.broadcastPeerList();
+                discovery.onMessage(dto, peer);
+                if (fresh) {
+                    syncService.followPeer(peer).subscribe();
+                }
+                return;
             }
-            return;
-        }
 
-        if (dto instanceof PeerListDto pl) {
-            List<Peer> peers = pl.peers().stream().map(Peer::fromString).toList();
-            registry.addAll(peers);
-            return;
-        }
+            if (dto instanceof PeerListDto pl) {
+                List<Peer> peers = pl.peers().stream().map(Peer::fromString).toList();
+                registry.addAll(peers);
+                return;
+            }
 
-        if (dto instanceof PingDto || dto instanceof PongDto ||
-            dto instanceof FindNodeDto || dto instanceof NodesDto) {
-            discovery.onMessage(dto, peer);
-        }
+            if (dto instanceof PingDto || dto instanceof PongDto ||
+                dto instanceof FindNodeDto || dto instanceof NodesDto) {
+                discovery.onMessage(dto, peer);
+            }
+        });
+
+        return session.send(Mono.just(session.textMessage(mapper.writeValueAsString(hello))))
+                      .then(session.closeStatus())
+                      .then();
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServerTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.ArgumentCaptor;
-import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.CloseStatus;
+import org.springframework.web.reactive.socket.HandshakeInfo;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -31,8 +33,10 @@ import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.P2PBroadcastService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
 import de.flashyotter.blockchain_node.service.SyncService;
+import de.flashyotter.blockchain_node.p2p.ConnectionManager;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
+import reactor.core.publisher.Mono;
 
 class PeerServerTest {
 
@@ -44,108 +48,122 @@ class PeerServerTest {
     @Mock PeerDiscoveryService discovery;
     @Mock SyncService syncService;
     @Mock WebSocketSession session;
+    @Mock HandshakeInfo info;
     @Mock reactor.netty.http.client.HttpClient httpClient;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         try { when(mapper.writeValueAsString(any())).thenReturn("{}"); } catch (Exception ignored) {}
+        when(session.getHandshakeInfo()).thenReturn(info);
+        when(session.receive()).thenReturn(Flux.never());
+        when(session.send(org.mockito.ArgumentMatchers.any())).thenReturn(Mono.empty());
+        when(session.closeStatus()).thenReturn(Mono.never());
+        when(session.textMessage(org.mockito.ArgumentMatchers.anyString())).thenReturn(org.mockito.Mockito.mock(WebSocketMessage.class));
     }
 
     @Test
-    void afterConnectionEstablished_registersSession() throws Exception {
+    void handleRegistersSession() {
         ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
         when(props.getId()).thenReturn("n1");
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 1));
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 1));
+        ConnectionManager.Conn conn = new ConnectionManager.Conn(Sinks.many().multicast().onBackpressureBuffer(),
+                                                                Sinks.many().multicast().onBackpressureBuffer(),
+                                                                Flux.empty());
+        when(manager.registerServerSession(any(), any())).thenReturn(conn);
 
-        peerServer.afterConnectionEstablished(session);
+        peerServer.handle(session).subscribe();
 
         verify(manager).registerServerSession(new Peer("host", 1), session);
-        verify(session).sendMessage(any(TextMessage.class));
+        verify(session).send(org.mockito.ArgumentMatchers.any());
     }
 
     @Test
-    void outboundMessagesAreSentThroughSession() throws Exception {
+    void outboundMessagesAreSentThroughSession() {
         var wsClient = org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class);
         ConnectionManager manager = new ConnectionManager(wsClient, mapper, props);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
         when(props.getId()).thenReturn("n1");
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 2));
-        when(session.isOpen()).thenReturn(true, false);
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 2));
 
-        peerServer.afterConnectionEstablished(session);
+        peerServer.handle(session).subscribe();
         ConnectionManager.Conn c = manager.connectAndSink(new Peer("host", 2));
         c.outbound().tryEmitNext("{\"hello\":1}");
 
         Awaitility.await().untilAsserted(() ->
-            verify(session, times(2)).sendMessage(any(TextMessage.class))
+            verify(session, times(2)).send(org.mockito.ArgumentMatchers.any())
         );
     }
 
     @Test
-    void closingSessionRemovesConnection() throws Exception {
+    void closingSessionRemovesConnection() {
         var wsClient = org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class);
         ConnectionManager manager = new ConnectionManager(wsClient, mapper, props);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
         when(props.getId()).thenReturn("n1");
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 3));
-        when(session.isOpen()).thenReturn(true, false);
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 3));
+        Sinks.One<CloseStatus> close = Sinks.one();
+        when(session.closeStatus()).thenReturn(close.asMono());
 
-        peerServer.afterConnectionEstablished(session);
+        peerServer.handle(session).subscribe();
         Peer peer = new Peer("host", 3);
         ConnectionManager.Conn first = manager.connectAndSink(peer);
 
+        close.tryEmitValue(CloseStatus.NORMAL);
         Awaitility.await().until(() -> !manager.connectAndSink(peer).equals(first));
     }
 
     @Test
-    void handleHandshake_addsPeerAndBroadcasts() throws Exception {
-        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+    void handleHandshake_addsPeerAndBroadcasts() {
+        ConnectionManager manager = new ConnectionManager(org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class), mapper, props);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 9));
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("host", 9));
         HandshakeDto dto = new HandshakeDto("n2", "0.4.0");
-        when(mapper.readValue("{}", P2PMessageDto.class)).thenReturn(dto);
         when(registry.add(any())).thenReturn(true);
         when(syncService.followPeer(any())).thenReturn(Flux.empty());
 
-        peerServer.handleTextMessage(session, new TextMessage("{}"));
-
+        peerServer.handle(session).subscribe();
         Peer peer = new Peer("host", 9);
-        verify(registry).add(peer);
-        verify(broadcastService).broadcastPeerList();
-        verify(discovery).onMessage(dto, peer);
-        verify(syncService).followPeer(peer);
+        manager.emitInbound(peer, dto);
+
+        Awaitility.await().untilAsserted(() -> {
+            verify(registry).add(peer);
+            verify(broadcastService).broadcastPeerList();
+            verify(discovery).onMessage(dto, peer);
+            verify(syncService).followPeer(peer);
+        });
     }
 
     @Test
-    void handlePeerList_addsPeers() throws Exception {
-        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+    void handlePeerList_addsPeers() {
+        ConnectionManager manager = new ConnectionManager(org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class), mapper, props);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("src", 4));
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("src", 4));
         PeerListDto dto = new PeerListDto(java.util.List.of("h1:1", "h2:2"));
-        when(mapper.readValue("json", P2PMessageDto.class)).thenReturn(dto);
 
-        peerServer.handleTextMessage(session, new TextMessage("json"));
+        peerServer.handle(session).subscribe();
+        manager.emitInbound(new Peer("src", 4), dto);
 
         java.util.List<Peer> expected = java.util.List.of(new Peer("h1",1), new Peer("h2",2));
-        verify(registry).addAll(expected);
+        Awaitility.await().untilAsserted(() -> verify(registry).addAll(expected));
     }
 
     @Test
-    void handleDiscoveryMessages_delegateToService() throws Exception {
-        ConnectionManager manager = org.mockito.Mockito.mock(ConnectionManager.class);
+    void handleDiscoveryMessages_delegateToService() {
+        ConnectionManager manager = new ConnectionManager(org.mockito.Mockito.mock(org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient.class), mapper, props);
         PeerServer peerServer = new PeerServer(mapper, nodeService, registry, broadcastService, props, discovery, manager, syncService);
-        when(session.getRemoteAddress()).thenReturn(new InetSocketAddress("h", 5));
-        when(mapper.readValue(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq(P2PMessageDto.class)))
-            .thenReturn(new PingDto("a"), new PongDto("b"), new FindNodeDto("c"), new NodesDto(java.util.List.of()));
+        when(info.getRemoteAddress()).thenReturn(new InetSocketAddress("h", 5));
 
-        peerServer.handleTextMessage(session, new TextMessage("1"));
-        peerServer.handleTextMessage(session, new TextMessage("2"));
-        peerServer.handleTextMessage(session, new TextMessage("3"));
-        peerServer.handleTextMessage(session, new TextMessage("4"));
+        peerServer.handle(session).subscribe();
+        manager.emitInbound(new Peer("h", 5), new PingDto("a"));
+        manager.emitInbound(new Peer("h", 5), new PongDto("b"));
+        manager.emitInbound(new Peer("h", 5), new FindNodeDto("c"));
+        manager.emitInbound(new Peer("h", 5), new NodesDto(java.util.List.of()));
 
         Peer peer = new Peer("h", 5);
-        verify(discovery, times(4)).onMessage(any(), org.mockito.ArgumentMatchers.eq(peer));
+        Awaitility.await().untilAsserted(() ->
+            verify(discovery, times(4)).onMessage(any(), org.mockito.ArgumentMatchers.eq(peer))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- use `WebSocketHandler` from WebFlux for peer connections
- hook up outbound/inbound handling using reactive `WebSocketSession`
- map `/ws` with a `SimpleUrlHandlerMapping`
- update `PeerServerTest` for the reactive API

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68623e65df588326a826435f0509fcef