### PR TITLE
Implement deterministic genesis and stricter block validation

### DIFF
--- a/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
@@ -1,0 +1,59 @@
+package simple.blockchain.consensus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.consensus.ConsensusParams;
+import blockchain.core.exceptions.BlockchainException;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.TxInput;
+import blockchain.core.model.TxOutput;
+import blockchain.core.model.Wallet;
+
+/** Tests for block validation rules enforced by Chain. */
+class BlockValidationTest {
+
+    @Test
+    @DisplayName("Block with unknown UTXO is rejected")
+    void rejectMissingUtxo() {
+        Chain chain = new Chain();
+        Block prev  = chain.getLatest();
+        Wallet miner = new Wallet();
+
+        Transaction coinbase = new Transaction(miner.getPublicKey(),
+                                               ConsensusParams.blockReward(1));
+        Transaction tx = new Transaction();
+        tx.getInputs().add(new TxInput("doesnt:exist", new byte[0], miner.getPublicKey()));
+        tx.getOutputs().add(new TxOutput(1.0, miner.getPublicKey()));
+        tx.signInputs(miner.getPrivateKey());
+
+        Block b = new Block(1, prev.getHashHex(), List.of(coinbase, tx), prev.getCompactDifficultyBits());
+        b.mineLocally();
+
+        BlockchainException ex = assertThrows(BlockchainException.class, () -> chain.addBlock(b));
+        assertEquals("UTXO not found", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Coinbase reward exceeding limit is rejected")
+    void rejectExcessiveCoinbase() {
+        Chain chain = new Chain();
+        Block prev  = chain.getLatest();
+        Wallet miner = new Wallet();
+
+        Transaction coinbase = new Transaction(miner.getPublicKey(),
+                                               ConsensusParams.blockReward(1) * 2);
+        Block b = new Block(1, prev.getHashHex(), List.of(coinbase), prev.getCompactDifficultyBits());
+        b.mineLocally();
+
+        BlockchainException ex = assertThrows(BlockchainException.class, () -> chain.addBlock(b));
+        assertEquals("excessive coinbase", ex.getMessage());
+    }
+}

--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -4,7 +4,7 @@ Important paths under `src/main/java/de/flashyotter/blockchain_node`:
 - `BlockchainNodeApplication.java` – entry point starting the HTTP & WebSocket server.
 - `bootstrap/StartupInitializer.java` – tasks executed at startup.
 - `config/` – Spring configuration classes (`SecurityConfig`, `WebSocketConfig`, ...).
-- `controler/` – REST controllers for chain, mining, transactions and wallet.
+- `controller/` – REST controllers for chain, mining, transactions and wallet.
 - `service/` – business logic (`NodeService`, `MiningService`, etc.).
 - `p2p/` – `Peer`, `PeerClient` and `PeerServer` for WebSocket networking.
 - `storage/` – `BlockStore` with LevelDB and in-memory implementations.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/ChainController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/ChainController.java
@@ -1,4 +1,4 @@
-package de.flashyotter.blockchain_node.controler;
+package de.flashyotter.blockchain_node.controller;
 
 import blockchain.core.model.Block;
 import de.flashyotter.blockchain_node.service.NodeService;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/MiningController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/MiningController.java
@@ -1,4 +1,4 @@
-package de.flashyotter.blockchain_node.controler;
+package de.flashyotter.blockchain_node.controller;
 
 import blockchain.core.model.Block;
 import de.flashyotter.blockchain_node.service.NodeService;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/RestErrorHandler.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/RestErrorHandler.java
@@ -1,4 +1,4 @@
-package de.flashyotter.blockchain_node.controler;
+package de.flashyotter.blockchain_node.controller;
 
 import blockchain.core.exceptions.BlockchainException;
 import org.springframework.http.HttpStatus;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/TxController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/TxController.java
@@ -1,4 +1,4 @@
-package de.flashyotter.blockchain_node.controler;
+package de.flashyotter.blockchain_node.controller;
 
 import blockchain.core.model.Transaction;
 import de.flashyotter.blockchain_node.service.NodeService;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/WalletController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/WalletController.java
@@ -1,4 +1,4 @@
-package de.flashyotter.blockchain_node.controler;
+package de.flashyotter.blockchain_node.controller;
 
 import blockchain.core.crypto.AddressUtils;
 import blockchain.core.model.Transaction;

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/ChainControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/ChainControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import blockchain.core.model.Block;
-import de.flashyotter.blockchain_node.controler.ChainController;
+import de.flashyotter.blockchain_node.controller.ChainController;
 import de.flashyotter.blockchain_node.service.NodeService;
 
 @WebMvcTest(ChainController.class)

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/MiningControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/MiningControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import blockchain.core.model.Block;
-import de.flashyotter.blockchain_node.controler.MiningController;
+import de.flashyotter.blockchain_node.controller.MiningController;
 import de.flashyotter.blockchain_node.service.NodeService;
 import reactor.core.publisher.Mono;
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/TxControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/TxControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import blockchain.core.model.Transaction;
-import de.flashyotter.blockchain_node.controler.TxController;
+import de.flashyotter.blockchain_node.controller.TxController;
 import de.flashyotter.blockchain_node.service.NodeService;
 
 @WebMvcTest(TxController.class)

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import blockchain.core.crypto.AddressUtils;
 import blockchain.core.model.Transaction;
 import blockchain.core.model.Wallet;
-import de.flashyotter.blockchain_node.controler.WalletController;
+import de.flashyotter.blockchain_node.controller.WalletController;
 import de.flashyotter.blockchain_node.dto.SendFundsDto;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.wallet.WalletService;


### PR DESCRIPTION
## Summary
- enforce UTXO checks and coinbase limits when adding blocks
- create deterministic genesis block so nodes share the same starting point
- rename `controler` package to `controller`
- update docs accordingly and add unit tests for new validation rules

## Testing
- `./gradlew clean test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686265d5f22c83268de546ac80e09aed