### PR TITLE
Deterministic coinbase hashes

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java
+++ b/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java
@@ -94,7 +94,8 @@ public class Chain {
     private static Block createGenesis() {
         Wallet miner = deterministicWallet();
         Transaction cb = new Transaction(miner.getPublicKey(),
-                                         ConsensusParams.blockReward(0));
+                                         ConsensusParams.blockReward(0),
+                                         "GENESIS");
         return new Block(0, "0".repeat(64),
                          List.of(cb), 0x1f0fffff,
                          1_694_303_200_000L, 0);

--- a/blockchain-core/src/main/java/blockchain/core/model/Transaction.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/Transaction.java
@@ -14,6 +14,7 @@ public class Transaction {
     private final List<TxInput>  inputs  = new ArrayList<>();
     private final List<TxOutput> outputs = new ArrayList<>();
     private String txHashHex;                      // lazily computed
+    private String coinbaseNonce;                  // for deterministic hashing
 
     /* ------------------------------------------------------------------ */
     /* ctors                                                              */
@@ -60,10 +61,16 @@ public class Transaction {
     }
 
     // coin-base convenience ctor
-public Transaction(PublicKey recipient, double reward) {
-    outputs.add(new TxOutput(reward, recipient));   // ⇐ now uses the new ctor above
-    // no inputs
-}
+    public Transaction(PublicKey recipient, double reward) {
+        this(recipient, reward, null);
+    }
+
+    /** Coinbase constructor allowing an explicit nonce/height value. */
+    public Transaction(PublicKey recipient, double reward, String coinbaseNonce) {
+        outputs.add(new TxOutput(reward, recipient));
+        this.coinbaseNonce = coinbaseNonce;
+        // no inputs
+    }
 
 /* -------- internal -------- */
 private String computeTxHashHex() {
@@ -72,7 +79,7 @@ private String computeTxHashHex() {
     // NOTE: recipientAddress(), not recipient()
     outputs.forEach(o -> sb.append(o.recipientAddress()).append(o.value()));
     if (isCoinbase()) {
-        sb.append(System.identityHashCode(this));   // oder height, timestamp, …
+        if (coinbaseNonce != null) sb.append(coinbaseNonce);
     }
     return HashingUtils.computeSha256Hex(sb.toString());
 }

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
@@ -28,7 +28,8 @@ class BlockValidationTest {
         Wallet miner = new Wallet();
 
         Transaction coinbase = new Transaction(miner.getPublicKey(),
-                                               ConsensusParams.blockReward(1));
+                                               ConsensusParams.blockReward(1),
+                                               "1");
         Transaction tx = new Transaction();
         tx.getInputs().add(new TxInput("doesnt:exist", new byte[0], miner.getPublicKey()));
         tx.getOutputs().add(new TxOutput(1.0, miner.getPublicKey()));
@@ -49,7 +50,8 @@ class BlockValidationTest {
         Wallet miner = new Wallet();
 
         Transaction coinbase = new Transaction(miner.getPublicKey(),
-                                               ConsensusParams.blockReward(1) * 2);
+                                               ConsensusParams.blockReward(1) * 2,
+                                               "1");
         Block b = new Block(1, prev.getHashHex(), List.of(coinbase), prev.getCompactDifficultyBits());
         b.mineLocally();
 

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/ChainEdgeCaseTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/ChainEdgeCaseTest.java
@@ -66,7 +66,8 @@ class ChainEdgeCaseTest {
         Wallet miner = new Wallet();
 
         Transaction cb = new Transaction(miner.getPublicKey(),
-                                         ConsensusParams.blockReward(1));
+                                         ConsensusParams.blockReward(1),
+                                         "1");
         int bits = chain.getLatest().getCompactDifficultyBits();
 
         Block candidate = new Block(1, "deadbeef".repeat(8), List.of(cb), bits);
@@ -87,7 +88,8 @@ class ChainEdgeCaseTest {
 
         /* ---------- Branch A (2 Blöcke) ------------------------------ */
         Transaction cb1 = new Transaction(miner.getPublicKey(),
-                                          ConsensusParams.blockReward(1));
+                                          ConsensusParams.blockReward(1),
+                                          "1");
         Block a1 = new Block(1, g.getHashHex(), List.of(cb1),
                              g.getCompactDifficultyBits());
         a1.mineLocally();
@@ -95,14 +97,16 @@ class ChainEdgeCaseTest {
 
         /* ---------- konkurrierende Branch B (3 Blöcke, mehr Arbeit) -- */
         Transaction cb2 = new Transaction(miner.getPublicKey(),
-                                          ConsensusParams.blockReward(1));
+                                          ConsensusParams.blockReward(1),
+                                          "1");
         Block b1 = new Block(1, g.getHashHex(), List.of(cb2),
                              g.getCompactDifficultyBits());
         b1.mineLocally();
         c.addBlock(b1);
 
         Transaction cb3 = new Transaction(miner.getPublicKey(),
-                                          ConsensusParams.blockReward(2));
+                                          ConsensusParams.blockReward(2),
+                                          "2");
         Block b2 = new Block(2, b1.getHashHex(), List.of(cb3),
                              g.getCompactDifficultyBits());
         b2.mineLocally();

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/ConsensusTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/ConsensusTest.java
@@ -44,7 +44,8 @@ class ChainTest {
         // craft coinbase & candidate block
         Wallet miner     = new Wallet();
         Transaction cb   = new Transaction(miner.getPublicKey(),
-                                           ConsensusParams.blockReward(1));
+                                           ConsensusParams.blockReward(1),
+                                           "1");
         Block candidate  = new Block(
                 1, prev.getHashHex(), List.of(cb), prev.getCompactDifficultyBits());
 
@@ -72,7 +73,8 @@ class ChainTest {
 
         Wallet miner = new Wallet();
         Transaction cb = new Transaction(miner.getPublicKey(),
-                                         ConsensusParams.blockReward(1));
+                                         ConsensusParams.blockReward(1),
+                                         "1");
 
         Block bogus = new Block(
                 1, "deadbeef".repeat(8), List.of(cb),

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/DifficultyRetargetIt.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/DifficultyRetargetIt.java
@@ -33,7 +33,8 @@ class DifficultyRetargetIT {
 
         for (int h = 1; h <= ConsensusParams.RETARGET_SPAN; h++) {
             Transaction coinbase = new Transaction(miner.getPublicKey(),
-                                                   ConsensusParams.blockReward(h));
+                                                   ConsensusParams.blockReward(h),
+                                                   String.valueOf(h));
             Block b = new Block(
                     h,
                     prev.getHashHex(),

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/MiningIncreasesHeightTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/MiningIncreasesHeightTest.java
@@ -19,7 +19,7 @@ class MiningIncreasesHeightTest {
         Block g     = c.getLatest();
         Wallet miner = new Wallet();
 
-        Transaction cb = new Transaction(miner.getPublicKey(), 50.0);
+        Transaction cb = new Transaction(miner.getPublicKey(), 50.0, "1");
         Block b = new Block(
                 1, g.getHashHex(), List.of(cb), g.getCompactDifficultyBits());
         b.mineLocally();

--- a/blockchain-core/src/test/java/simple/blockchain/mempool/MempoolTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/mempool/MempoolTest.java
@@ -23,7 +23,7 @@ class MempoolTest {
     @DisplayName("Coinbase transactions are rejected by the mem-pool")
     void rejectCoinbase() {
         Wallet miner = new Wallet();
-        Transaction coinbase = new Transaction(miner.getPublicKey(), 50.0);
+        Transaction coinbase = new Transaction(miner.getPublicKey(), 50.0, "0");
 
         Mempool mp = new Mempool();
         assertThrows(BlockchainException.class,

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MiningService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MiningService.java
@@ -33,7 +33,9 @@ public class MiningService {
         int height   = chain.getLatest().getHeight() + 1;
         double reward = ConsensusParams.blockReward(height);
         Transaction coinbase = new Transaction(
-                wallet.getLocalWallet().getPublicKey(), reward);
+                wallet.getLocalWallet().getPublicKey(),
+                reward,
+                String.valueOf(height));
 
         /* 3) Liste zusammenstellen  (coinbase immer an Position 0) ------ */
         List<Transaction> txs = new java.util.ArrayList<>(1 + memTx.size());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
@@ -30,7 +30,9 @@ class ChainBootstrapTest {
     }
 
     private Block mineBlock(int height, String prevHash, int bits, Wallet miner) {
-        Transaction cb = new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(height));
+        Transaction cb = new Transaction(miner.getPublicKey(),
+                                         ConsensusParams.blockReward(height),
+                                         String.valueOf(height));
         Block b = new Block(height, prevHash, List.of(cb), bits);
         b.mineLocally();
         return b;

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceUtxoRebuildIT.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceUtxoRebuildIT.java
@@ -30,7 +30,7 @@ class NodeServiceUtxoRebuildIT {
         Chain   chain   = new Chain();
         Wallet  miner   = new Wallet();
 
-        Transaction coinbase = new Transaction(miner.getPublicKey(), 50.0);
+        Transaction coinbase = new Transaction(miner.getPublicKey(), 50.0, "1");
         Block b1 = new Block(
                 1,
                 chain.getLatest().getHashHex(),


### PR DESCRIPTION
## Summary
- support deterministic coinbase hashes by passing a nonce
- include nonce in `Transaction` hashing
- inject constant nonce when creating genesis block
- pass block height as nonce for mined blocks
- update tests accordingly

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68628cd06af8832684ba9bd312df5d07