### PR TITLE
enforce coinbase maturity rule

### DIFF
--- a/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/BlockValidationTest.java
@@ -61,31 +61,115 @@ class BlockValidationTest {
     }
 
     @Test
-    @DisplayName("Outputs from the same block can be spent")
+    @DisplayName("Outputs from earlier tx in the same block can be spent")
     void spendOutputsWithinBlock() {
         Chain chain = new Chain();
         Block prev  = chain.getLatest();
 
-        Wallet alice = new Wallet();
-        Wallet bob   = new Wallet();
+        Wallet miner = new Wallet();
+        Transaction firstCb = new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(1), "1");
+        Block first = new Block(1, prev.getHashHex(), List.of(firstCb), prev.getCompactDifficultyBits());
+        first.mineLocally();
+        chain.addBlock(first);
 
-        Transaction coinbase = new Transaction(alice.getPublicKey(),
-                                               ConsensusParams.blockReward(1),
-                                               "1");
-        String cbOutId = coinbase.getOutputs().get(0)
-                                  .id(coinbase.calcHashHex(), 0);
+        String matureId = firstCb.getOutputs().get(0).id(firstCb.calcHashHex(), 0);
+
+        // advance chain to mature the coinbase
+        Block last = first;
+        for (int h = 2; h <= ConsensusParams.COINBASE_MATURITY; h++) {
+            Transaction cb = new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(h), String.valueOf(h));
+            Block filler = new Block(h, last.getHashHex(), List.of(cb), last.getCompactDifficultyBits());
+            filler.mineLocally();
+            chain.addBlock(filler);
+            last = filler;
+        }
+
+        Wallet bob   = new Wallet();
+        Wallet charlie = new Wallet();
+
+        Transaction fund = new Transaction();
+        fund.getInputs().add(new TxInput(matureId, new byte[0], miner.getPublicKey()));
+        fund.getOutputs().add(new TxOutput(ConsensusParams.blockReward(1), bob.getPublicKey()));
+        fund.signInputs(miner.getPrivateKey());
+        String fundOut = fund.getOutputs().get(0).id(fund.calcHashHex(), 0);
 
         Transaction spend = new Transaction();
-        spend.getInputs().add(new TxInput(cbOutId, new byte[0], alice.getPublicKey()));
-        spend.getOutputs().add(new TxOutput(ConsensusParams.blockReward(1), bob.getPublicKey()));
-        spend.signInputs(alice.getPrivateKey());
+        spend.getInputs().add(new TxInput(fundOut, new byte[0], bob.getPublicKey()));
+        spend.getOutputs().add(new TxOutput(ConsensusParams.blockReward(1), charlie.getPublicKey()));
+        spend.signInputs(bob.getPrivateKey());
 
-        Block b = new Block(1, prev.getHashHex(), List.of(coinbase, spend), prev.getCompactDifficultyBits());
+        Block b = new Block(last.getHeight() + 1, last.getHashHex(), List.of(new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(last.getHeight() + 1), "x"), fund, spend), last.getCompactDifficultyBits());
         b.mineLocally();
 
         chain.addBlock(b);
 
         String spendId = spend.getOutputs().get(0).id(spend.calcHashHex(), 0);
-        assertTrue(chain.getUtxoSnapshot().containsKey(spendId), "spend output in UTXO");
+        assertTrue(chain.getUtxoSnapshot().containsKey(spendId));
+    }
+
+    @Test
+    @DisplayName("Coinbase outputs require maturity before spending")
+    void rejectImmatureCoinbaseSpend() {
+        Chain chain = new Chain();
+        Block prev  = chain.getLatest();
+
+        Wallet miner = new Wallet();
+        Transaction coinbase = new Transaction(miner.getPublicKey(),
+                                               ConsensusParams.blockReward(1),
+                                               "1");
+        String cbOut = coinbase.getOutputs().get(0)
+                               .id(coinbase.calcHashHex(), 0);
+
+        Transaction spend = new Transaction();
+        spend.getInputs().add(new TxInput(cbOut, new byte[0], miner.getPublicKey()));
+        spend.getOutputs().add(new TxOutput(ConsensusParams.blockReward(1), miner.getPublicKey()));
+        spend.signInputs(miner.getPrivateKey());
+
+        Block b = new Block(1, prev.getHashHex(), List.of(coinbase, spend), prev.getCompactDifficultyBits());
+        b.mineLocally();
+
+        BlockchainException ex = assertThrows(BlockchainException.class, () -> chain.addBlock(b));
+        assertEquals("coinbase immature", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Coinbase outputs may be spent after maturity")
+    void spendMatureCoinbase() {
+        Chain chain = new Chain();
+        Block prev  = chain.getLatest();
+
+        Wallet miner = new Wallet();
+        Transaction coinbase = new Transaction(miner.getPublicKey(),
+                                               ConsensusParams.blockReward(1),
+                                               "1");
+        Block first = new Block(1, prev.getHashHex(), List.of(coinbase), prev.getCompactDifficultyBits());
+        first.mineLocally();
+        chain.addBlock(first);
+
+        String cbOut = coinbase.getOutputs().get(0)
+                               .id(coinbase.calcHashHex(), 0);
+
+        // Mine maturity blocks with empty coinbase transactions
+        Block prevBlock = first;
+        for (int h = 2; h <= ConsensusParams.COINBASE_MATURITY; h++) {
+            Transaction cb = new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(h), String.valueOf(h));
+            Block filler = new Block(h, prevBlock.getHashHex(), List.of(cb), prevBlock.getCompactDifficultyBits());
+            filler.mineLocally();
+            chain.addBlock(filler);
+            prevBlock = filler;
+        }
+
+        Transaction spend = new Transaction();
+        spend.getInputs().add(new TxInput(cbOut, new byte[0], miner.getPublicKey()));
+        spend.getOutputs().add(new TxOutput(ConsensusParams.blockReward(1), miner.getPublicKey()));
+        spend.signInputs(miner.getPrivateKey());
+
+        Block mature = new Block(prevBlock.getHeight() + 1, prevBlock.getHashHex(), List.of(new Transaction(miner.getPublicKey(), ConsensusParams.blockReward(prevBlock.getHeight() + 1), "m"), spend), prevBlock.getCompactDifficultyBits());
+        mature.mineLocally();
+
+        chain.addBlock(mature);
+
+        String spendId = spend.getOutputs().get(0).id(spend.calcHashHex(), 0);
+        assertTrue(chain.getUtxoSnapshot().containsKey(spendId));
     }
 }


### PR DESCRIPTION
## Summary
- track the block height of coinbase outputs
- reject spending immature coinbase outputs in `validateTxs`
- rebuild coinbase info during re-orgs
- add consensus tests for immature and mature coinbase spends

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686296db6554832688c450a4d53878b4