### PR TITLE
Implement pruning for DAG maps

### DIFF
--- a/blockchain-core/src/test/java/simple/blockchain/consensus/PruningTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/PruningTest.java
@@ -1,0 +1,42 @@
+package simple.blockchain.consensus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.Wallet;
+
+class PruningTest {
+    @Test
+    void pruneRemovesOldForkBlocks() {
+        Chain chain = new Chain();
+        Block genesis = chain.getLatest();
+        Wallet miner = new Wallet();
+
+        // extend main chain by three blocks
+        Block prev = genesis;
+        for (int i = 1; i <= 3; i++) {
+            Transaction cb = new Transaction(miner.getPublicKey(), 50.0, String.valueOf(i));
+            Block blk = new Block(i, prev.getHashHex(), List.of(cb), prev.getCompactDifficultyBits());
+            blk.mineLocally();
+            chain.addBlock(blk);
+            prev = blk;
+        }
+
+        // side fork at height 1
+        Transaction cbFork = new Transaction(miner.getPublicKey(), 50.0, "fork");
+        Block fork = new Block(1, genesis.getHashHex(), List.of(cbFork), genesis.getCompactDifficultyBits());
+        fork.mineLocally();
+        chain.addBlock(fork);
+
+        List<Block> removed = chain.pruneOldBlocks(2);
+
+        assertTrue(removed.contains(fork), "fork block pruned");
+        assertEquals(4, chain.getBlocks().size(), "active chain intact");
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PruningService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PruningService.java
@@ -1,0 +1,43 @@
+package de.flashyotter.blockchain_node.service;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import de.flashyotter.blockchain_node.storage.BlockStore;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.List;
+
+/** Periodically prunes old fork data from the in-memory chain. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PruningService {
+    private final Chain chain;
+    private final BlockStore store;
+
+    private static final int KEEP_BLOCKS = 1000;
+
+    @PostConstruct
+    void start() {
+        Schedulers.boundedElastic().schedule(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(60_000);
+                    List<Block> removed = chain.pruneOldBlocks(KEEP_BLOCKS);
+                    for (Block b : removed) {
+                        store.save(b);
+                    }
+                    if (!removed.isEmpty()) {
+                        log.info("Pruned {} blocks from DAG", removed.size());
+                    }
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `pruneOldBlocks()` to `Chain` to remove old fork data
- create `PruningService` in the node module to periodically prune
- test pruning logic on the core chain

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_68629c5cbfb0832686648f6ae9e2106e