### PR TITLE
Fix stale mempool eviction

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/mempool/Mempool.java
+++ b/blockchain-core/src/main/java/blockchain/core/mempool/Mempool.java
@@ -18,7 +18,7 @@ public class Mempool {
     private final PriorityQueue<Entry> byFee = new PriorityQueue<>(Comparator.comparingDouble(e -> e.fee));
     private final int maxSize;
 
-    private record Entry(Transaction tx, double fee) {}
+    private record Entry(String txHash, Transaction tx, double fee) {}
 
     public Mempool() { this(DEFAULT_MAX); }
 
@@ -44,14 +44,14 @@ public class Mempool {
                 throw new BlockchainException("double-spend in mempool");
         }
         double fee = calcFee(tx, utxo);
-        Entry entry = new Entry(tx, fee);
         String id = tx.calcHashHex();
+        Entry entry = new Entry(id, tx, fee);
         synchronized (this) {
             pool.put(id, entry);
             byFee.add(entry);
             if (pool.size() > maxSize) {
                 Entry evicted = byFee.poll();
-                pool.values().removeIf(e -> e.equals(evicted));
+                pool.remove(evicted.tx().calcHashHex());
             }
         }
     }


### PR DESCRIPTION
## Summary
- embed tx hash in `Mempool.Entry`
- remove evicted tx via its hash to avoid stale entries

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68629fca9dec8326ac5e5a1452f533e1