### PR TITLE
Support mempool-aware UTXO validation

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/NodeService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/NodeService.java
@@ -57,7 +57,7 @@ public class NodeService {
     /* ---------- transactions ---------- */
 
     public void submitTx(Transaction tx) {
-        mempool.submit(tx, currentUtxo());
+        mempool.submit(tx, currentUtxoIncludingPending());
         broadcaster.broadcastTx(
             new NewTxDto(blockchain.core.serialization.JsonUtils.toJson(tx)),
             null
@@ -65,7 +65,7 @@ public class NodeService {
     }
 
     public void acceptExternalTx(Transaction tx) {
-        mempool.submit(tx, currentUtxo());
+        mempool.submit(tx, currentUtxoIncludingPending());
     }
 
     /* ---------- blocks from peers ---------- */

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceDoubleSpendTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceDoubleSpendTest.java
@@ -1,0 +1,61 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.exceptions.BlockchainException;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.TxInput;
+import blockchain.core.model.TxOutput;
+import blockchain.core.model.Wallet;
+import de.flashyotter.blockchain_node.storage.InMemoryBlockStore;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+/** Verifies that double-spends are rejected across pending transactions. */
+class NodeServiceDoubleSpendTest {
+
+    @Test
+    void doubleSpendIsRejected() {
+        // create a chain with one spendable output to alice
+        Chain chain = new Chain();
+        Wallet alice = new Wallet();
+        Transaction coinbase = new Transaction(alice.getPublicKey(), 10.0, "cb");
+        Block blk = new Block(
+                1,
+                chain.getLatest().getHashHex(),
+                List.of(coinbase),
+                chain.getLatest().getCompactDifficultyBits()
+        );
+        blk.mineLocally();
+        chain.addBlock(blk);
+
+        MempoolService mempool = new MempoolService();
+        NodeService svc = new NodeService(
+                chain,
+                mempool,
+                Mockito.mock(MiningService.class),
+                Mockito.mock(P2PBroadcastService.class),
+                new InMemoryBlockStore()
+        );
+
+        // spend the coinbase output once
+        String utxoId = coinbase.getOutputs().get(0).id(coinbase.calcHashHex(), 0);
+        Transaction tx1 = new Transaction();
+        tx1.getInputs().add(new TxInput(utxoId, new byte[0], alice.getPublicKey()));
+        tx1.getOutputs().add(new TxOutput(10.0, alice.getPublicKey()));
+        tx1.signInputs(alice.getPrivateKey());
+        svc.submitTx(tx1);
+
+        // second spend of the same output must fail
+        Transaction tx2 = new Transaction();
+        tx2.getInputs().add(new TxInput(utxoId, new byte[0], alice.getPublicKey()));
+        tx2.getOutputs().add(new TxOutput(10.0, alice.getPublicKey()));
+        tx2.signInputs(alice.getPrivateKey());
+
+        assertThrows(BlockchainException.class, () -> svc.submitTx(tx2));
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceTest.java
@@ -45,6 +45,7 @@ class NodeServiceTest {
         store       = mock(BlockStore.class);
 
         when(chain.getBlocks()).thenReturn(List.of());
+        when(mempool.take(Integer.MAX_VALUE)).thenReturn(List.of());
 
         svc = new NodeService(chain, mempool, mining, broadcaster, store);
     }


### PR DESCRIPTION
## Summary
- validate new mempool entries against confirmed + pending UTXO
- pass `currentUtxoIncludingPending` when submitting transactions
- stub pending transactions in `NodeServiceTest`
- test that double-spends are rejected

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862b2e34f0c8326a04de2c8cededd1b