### PR TITLE
Check P2P protocol version on handshake

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/PeerServer.java
@@ -54,6 +54,13 @@ public class PeerServer implements WebSocketHandler {
 
         conn.inbound().subscribe(dto -> {
             if (dto instanceof HandshakeDto hs) {
+                if (!PROTOCOL_VER.equals(hs.protocolVersion())) {
+                    log.warn("\u274c  incompatible peer {}: {} != {}",
+                             host, hs.protocolVersion(), PROTOCOL_VER);
+                    session.close().subscribe();
+                    return;
+                }
+
                 Peer real = new Peer(host, hs.listenPort());
                 actual.set(real);
                 boolean fresh = registry.add(real);


### PR DESCRIPTION
## Summary
- validate protocol version when receiving a `HandshakeDto`
- close session if the peer uses an incompatible protocol
- test closing the connection on version mismatch

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862b54205ac832691c2b6bcdec0a146