### PR TITLE
Add configurable mempool size

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -17,6 +17,10 @@ import java.util.List;
 public class NodeProperties {
     private List<String> peers = List.of();
 
+    /** Maximum number of transactions kept in the mempool */
+    @Value("${mempool.maxSize:1000}")
+    private int mempoolMaxSize = 1000;
+
     /** HTTP/WebSocket server port */
     @Value("${server.port:0}")
     private int port;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MempoolService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MempoolService.java
@@ -3,6 +3,7 @@ package de.flashyotter.blockchain_node.service;
 import blockchain.core.mempool.Mempool;
 import blockchain.core.model.Transaction;
 import blockchain.core.model.TxOutput;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,7 +16,11 @@ import java.util.Map;
 @Service
 public class MempoolService {
 
-    private final Mempool mempool = new Mempool();
+    private final Mempool mempool;
+
+    public MempoolService(NodeProperties props) {
+        this.mempool = new Mempool(props.getMempoolMaxSize());
+    }
 
     public void submit(Transaction tx, Map<String, TxOutput> utxo) {
         mempool.add(tx, utxo);

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -16,3 +16,6 @@ node:
   peers: []
   wallet-password: ${NODE_WALLET_PASSWORD:changeMe}
   jwt-secret:    ${NODE_JWT_SECRET:changeMeSuperSecret}
+
+mempool:
+  maxSize: 1000

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceDoubleSpendTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/NodeServiceDoubleSpendTest.java
@@ -9,6 +9,7 @@ import blockchain.core.model.Transaction;
 import blockchain.core.model.TxInput;
 import blockchain.core.model.TxOutput;
 import blockchain.core.model.Wallet;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.storage.InMemoryBlockStore;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -33,7 +34,8 @@ class NodeServiceDoubleSpendTest {
         blk.mineLocally();
         chain.addBlock(blk);
 
-        MempoolService mempool = new MempoolService();
+        NodeProperties props = new NodeProperties();
+        MempoolService mempool = new MempoolService(props);
         NodeService svc = new NodeService(
                 chain,
                 mempool,


### PR DESCRIPTION
## Summary
- expose `mempool.maxSize` in `application.yml`
- load mempool size via `NodeProperties`
- construct `MempoolService` with configured size
- adapt `NodeServiceDoubleSpendTest`

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_6862bb6e9818832699ffa93a9469a001