### PR TITLE
Add dataPath and wallet defaults

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -17,6 +17,9 @@ import java.util.List;
 public class NodeProperties {
     private List<String> peers = List.of();
 
+    /** Base directory for node data like the ID file. */
+    private String dataPath = "data";
+
     /** Maximum number of transactions kept in the mempool */
     @Value("${mempool.maxSize:1000}")
     private int mempoolMaxSize = 1000;
@@ -25,7 +28,7 @@ public class NodeProperties {
     @Value("${server.port:0}")
     private int port;
 
-    /** Stable node identifier persisted in data/nodeId */
+    /** Stable node identifier persisted in dataPath/nodeId */
     private String id;
     
     /**
@@ -36,7 +39,7 @@ public class NodeProperties {
     @PostConstruct
     private void initId() throws IOException {
         if (id != null && !id.isBlank()) return;
-        Path path = Path.of("data", "nodeId");
+        Path path = Path.of(dataPath, "nodeId");
         if (Files.exists(path)) {
             id = Files.readString(path).trim();
         } else {

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/PkcsKeyStoreProvider.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/PkcsKeyStoreProvider.java
@@ -9,6 +9,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +30,6 @@ import java.util.Optional;
 @Slf4j
 public class PkcsKeyStoreProvider implements KeyStoreProvider {
 
-    private static final String STORE_FILENAME = ".simple-chain/wallet.p12";
     private final char[] password;
     private final Path storePath;
 
@@ -37,12 +37,13 @@ public class PkcsKeyStoreProvider implements KeyStoreProvider {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    public PkcsKeyStoreProvider(NodeProperties props) {
+    public PkcsKeyStoreProvider(NodeProperties props,
+                               @Value("${wallet.store-path}") String storePath) {
         if (props.getWalletPassword() == null || props.getWalletPassword().isBlank()) {
             throw new IllegalArgumentException("node.walletPassword must be set");
         }
         this.password  = props.getWalletPassword().toCharArray();
-        this.storePath = Paths.get(System.getProperty("user.home"), STORE_FILENAME);
+        this.storePath = Paths.get(System.getProperty("user.home"), storePath);
     }
 
     @Override

--- a/blockchain-node/src/main/resources/application-test.yml
+++ b/blockchain-node/src/main/resources/application-test.yml
@@ -1,2 +1,6 @@
 node:
   wallet-password: test
+  data-path: data
+
+wallet:
+  store-path: .simple-chain/wallet.p12

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -14,8 +14,12 @@ server:
 
 node:
   peers: []
+  data-path: data
   wallet-password: ${NODE_WALLET_PASSWORD:changeMe}
   jwt-secret:    ${NODE_JWT_SECRET:changeMeSuperSecret}
+
+wallet:
+  store-path: .simple-chain/wallet.p12
 
 mempool:
   maxSize: 1000


### PR DESCRIPTION
## Summary
- extend node config defaults with `data-path` and `wallet` section
- store the base data directory in `NodeProperties`
- allow `PkcsKeyStoreProvider` to set a wallet store path from config
- provide defaults for Spring tests

## Testing
- `./gradlew clean test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6862c66f1468832688fc5e59128737bf