### PR TITLE
Implement WS handshake and reconnect logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ You can inspect traffic with any WS client:
 ws://host:port/ws
 ```
 
+### Frontend WebSocket Flow
+
+The React UI connects to the node via `VITE_NODE_WS` (e.g. `ws://localhost:3333/ws`).
+On connect it sends a `HandshakeDto` and automatically reconnects with
+exponential backoff if the socket closes. Only `NewBlockDto` and `NewTxDto`
+messages are forwarded to the app.
+
+
 ---
 
 ## Run a Private Network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_NODE_URL: http://localhost:${BACKEND_PORT}/api
-        VITE_NODE_WS: http://localhost:${BACKEND_PORT}/ws
+        VITE_NODE_WS: ws://localhost:${BACKEND_PORT}/ws
     ports:
       - "${FRONTEND_PORT}:80"
     depends_on:

--- a/ui/.env
+++ b/ui/.env
@@ -1,3 +1,3 @@
 # Adresse deines ersten Nodes
 VITE_NODE_URL=http://localhost:3333/api
-VITE_NODE_WS=http://localhost:3333/ws
+VITE_NODE_WS=ws://localhost:3333/ws

--- a/ui/src/__tests__/ws.test.ts
+++ b/ui/src/__tests__/ws.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NodeWs } from '../api/ws';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [] as MockWebSocket[];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  readyState = MockWebSocket.CONNECTING;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose && this.onclose({} as CloseEvent);
+  });
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances.length = 0;
+  (global as any).WebSocket = MockWebSocket;
+});
+
+describe('NodeWs', () => {
+  it('sends handshake on open', () => {
+    const ws = new NodeWs();
+    ws.connect();
+    const inst = MockWebSocket.instances[0];
+    inst.onopen && inst.onopen(new Event('open'));
+    expect(inst.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'HandshakeDto',
+        nodeId: 'ui-client',
+        protocolVersion: '0.4.0',
+        listenPort: 0,
+      }),
+    );
+  });
+
+  it('reconnects after close', () => {
+    vi.useFakeTimers();
+    const ws = new NodeWs();
+    ws.connect();
+    const first = MockWebSocket.instances[0];
+    first.onopen && first.onopen(new Event('open'));
+    first.onclose && first.onclose({} as CloseEvent);
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances.length).toBe(2);
+    vi.useRealTimers();
+  });
+
+  it('forwards only block and tx messages', () => {
+    const ws = new NodeWs();
+    const handler = vi.fn();
+    ws.on(handler);
+    ws.connect();
+    const inst = MockWebSocket.instances[0];
+    inst.onopen && inst.onopen(new Event('open'));
+    inst.onmessage && inst.onmessage({ data: JSON.stringify({ type: 'NewBlockDto', rawBlockJson: '{}' }) } as MessageEvent);
+    inst.onmessage && inst.onmessage({ data: JSON.stringify({ type: 'PeerListDto', peers: [] }) } as MessageEvent);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].type).toBe('NewBlockDto');
+  });
+});

--- a/ui/src/api/ws.ts
+++ b/ui/src/api/ws.ts
@@ -1,32 +1,74 @@
-export type Listener<T = unknown> = (msg: T) => void;
+export interface P2PMessage {
+  type: 'HandshakeDto' | 'NewBlockDto' | 'NewTxDto' | string;
+  rawBlockJson?: string;
+  rawTxJson?: string;
+}
 
-class NodeWs {
+export type Listener<T = P2PMessage> = (msg: T) => void;
+
+export class NodeWs {
   private ws?: WebSocket;
   private listeners: Listener[] = [];
+  private reconnectMs = 1000;
+  private closed = false;
 
   connect() {
+    this.closed = false;
+    this.open();
+  }
+
+  private open() {
     this.ws = new WebSocket(import.meta.env.VITE_NODE_WS);
+
+    this.ws.onopen = () => {
+      this.reconnectMs = 1000;
+      const hello = {
+        type: 'HandshakeDto',
+        nodeId: 'ui-client',
+        protocolVersion: '0.4.0',
+        listenPort: 0,
+      };
+      this.ws?.send(JSON.stringify(hello));
+    };
+
     this.ws.onmessage = ev => {
-      let data: unknown;
+      let data: P2PMessage;
       try {
         data = JSON.parse(ev.data);
       } catch {
-        return;                       // ignorieren bei JSON-Fehler
+        return; // ignorieren bei JSON-Fehler
       }
-      this.listeners.forEach(cb => cb(data));
+      if (data.type === 'NewBlockDto' || data.type === 'NewTxDto') {
+        this.listeners.forEach(cb => cb(data));
+      }
+    };
+
+    this.ws.onclose = () => {
+      if (!this.closed) this.scheduleReconnect();
+    };
+    this.ws.onerror = () => {
+      if (!this.closed) this.scheduleReconnect();
     };
   }
 
-  on<T = unknown>(cb: Listener<T>) { this.listeners.push(cb as Listener); }
-
-close() {
-  if (this.ws &&
-      (this.ws.readyState === WebSocket.OPEN ||
-       this.ws.readyState === WebSocket.CLOSING)) {
-    this.ws.close();
+  private scheduleReconnect() {
+    this.ws = undefined;
+    setTimeout(() => this.open(), this.reconnectMs);
+    this.reconnectMs = Math.min(this.reconnectMs * 2, 30000);
   }
-  this.ws = undefined;
-}
+
+  on<T = P2PMessage>(cb: Listener<T>) { this.listeners.push(cb as Listener); }
+
+  close() {
+    this.closed = true;
+    if (this.ws &&
+        (this.ws.readyState === WebSocket.OPEN ||
+         this.ws.readyState === WebSocket.CONNECTING ||
+         this.ws.readyState === WebSocket.CLOSING)) {
+      this.ws.close();
+    }
+    this.ws = undefined;
+  }
 }
 
 export const wsSingleton = new NodeWs();

--- a/ui/src/types/p2p.ts
+++ b/ui/src/types/p2p.ts
@@ -1,0 +1,5 @@
+export interface P2PMessage {
+  type: 'HandshakeDto' | 'NewBlockDto' | 'NewTxDto' | string;
+  rawBlockJson?: string;
+  rawTxJson?: string;
+}


### PR DESCRIPTION
## Summary
- add websocket handshake and reconnect logic
- filter only NewBlockDto and NewTxDto messages
- document websocket flow and environment variable in README
- ensure VITE_NODE_WS uses ws:// protocol
- add P2P message typings and unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d9706d5c8326ad15c898c1c2b4cf