### PR TITLE
Fix P2P port handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Example:
 
 ```bash
 # my wallet address & balance
-curl http://localhost:1002/api/wallet | jq
+curl http://localhost:$BACKEND_PORT/api/wallet | jq
 
 # pay 1.0 coin to recipientKey
-curl -X POST http://localhost:1002/api/wallet/send \
+curl -X POST http://localhost:$BACKEND_PORT/api/wallet/send \
      -H "Content-Type: application/json" \
      -d '{ "recipient":"MIGbMBAGByqG...", "amount":1.0 }'
 ```
@@ -84,7 +84,7 @@ ws://host:port/ws
 
 ### Frontend WebSocket Flow
 
-The React UI connects to the node via `VITE_NODE_WS` (e.g. `ws://localhost:3333/ws`).
+The React UI connects to the node via `VITE_NODE_WS` (e.g. `ws://localhost:$BACKEND_PORT/ws`).
 On connect it sends a `HandshakeDto` and automatically reconnects with
 exponential backoff if the socket closes. Only `NewBlockDto` and `NewTxDto`
 messages are forwarded to the app.

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
 
 server:
   address: 0.0.0.0
-  port: 3333
+  port: ${SERVER_PORT:3333}
 
 node:
   peers: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       NODE_WALLET_PASSWORD: "${NODE_WALLET_PASSWORD}"
       NODE_JWT_SECRET:     "${NODE_JWT_SECRET}"
       NODE_PEERS:          "${NODE_PEERS}"
+      SERVER_PORT:         "${BACKEND_PORT}"
     ports:
-      - "${BACKEND_PORT}:3333"
+      - "${BACKEND_PORT}:${BACKEND_PORT}"
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Summary
- allow overriding `server.port` via `SERVER_PORT`
- configure Compose to run backend on the same port inside/outside the container
- use `$BACKEND_PORT` in README examples

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686387a0b5bc8326acb2dcc6b9ffdda5