### PR TITLE
Align backend port configuration

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -7,7 +7,10 @@ RUN gradle :blockchain-node:bootJar --no-daemon
 
 # Run stage
 FROM eclipse-temurin:21-jre
+ARG SERVER_PORT=3333
+ENV SERVER_PORT=${SERVER_PORT}
 WORKDIR /app
 COPY --from=build /app/blockchain-node/build/libs/blockchain-node-0.0.1-SNAPSHOT.jar app.jar
-EXPOSE 8080
+# The port is configured via SERVER_PORT so Compose and this image stay aligned
+EXPOSE ${SERVER_PORT}
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A lightweight Proof-of-Work blockchain node written in **Java 21** + **Spring Bo
      BACKEND_PORT=1002
      FRONTEND_PORT=8892
      ```
+   `docker-compose` passes `BACKEND_PORT` to the backend container as `SERVER_PORT`.
+   The Docker image exposes this port and defaults to `3333` if not overridden.
 2. **Start the stack:**
    ```bash
    ./gradlew dockerComposeUp

--- a/blockchain-node/Dockerfile
+++ b/blockchain-node/Dockerfile
@@ -1,5 +1,8 @@
 FROM eclipse-temurin:21-jre
+ARG SERVER_PORT=3333
+ENV SERVER_PORT=${SERVER_PORT}
 WORKDIR /app
 COPY *.jar app.jar
-EXPOSE 3333
+# Expose the port defined by SERVER_PORT (defaults to 3333)
+EXPOSE ${SERVER_PORT}
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       NODE_WALLET_PASSWORD: "${NODE_WALLET_PASSWORD}"
       NODE_JWT_SECRET:     "${NODE_JWT_SECRET}"
       NODE_PEERS:          "${NODE_PEERS}"
+      # Keep container and host ports in sync
       SERVER_PORT:         "${BACKEND_PORT}"
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"


### PR DESCRIPTION
## Summary
- use `SERVER_PORT` arg in Dockerfiles and expose that port
- note the port mapping in `docker-compose.yml`
- document how the backend port is passed in the README

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68639576c698832695da6bedcc999a03