### PR TITLE
Update CA certificate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ A lightweight Proof-of-Work blockchain node written in **Java 21** + **Spring Bo
    ./gradlew dockerComposeDown
    ```
 
+### Zertifikat hinterlegen
+
+Setze die Variable `BUILD_CA_CERT` auf den absoluten Pfad zu deinem
+Zscaler-Root-Zertifikat **in Unix-Schreibweise**:
+
+Unix / Linux
+```bash
+export BUILD_CA_CERT=/opt/certs/zscaler.crt
+```
+
+Windows (PowerShell)
+```powershell
+setx BUILD_CA_CERT "C:/Users/maierm/zscaler/zscalerwsl.crt"
+```
+
+Wichtig: Vorwärtsschrägstriche (/) funktionieren auch unter Windows,
+weil `keytool` diese akzeptiert.
+
 ---
 
 ## REST API

--- a/blockchain-node/Dockerfile
+++ b/blockchain-node/Dockerfile
@@ -17,6 +17,19 @@ RUN if [ -n "$BUILD_CA_CERT" ] && [ -f "$BUILD_CA_CERT" ]; then \
       update-ca-certificates; \
     fi
 
+# --- Zertifikat ebenfalls in den JVM-Truststore legen --------------
+RUN if [ -n "$BUILD_CA_CERT" ] && [ -f "$BUILD_CA_CERT" ]; then \
+      keytool -importcert \
+              -alias zscaler \
+              -file "$BUILD_CA_CERT" \
+              -keystore "$JAVA_HOME/lib/security/cacerts" \
+              -storepass changeit \
+              -noprompt \
+              -trustcacerts && \
+      # Symlink, damit Linux-Store und JVM-Store identisch bleiben
+      ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
+    fi
+
 # Build only the node module
 RUN gradle :blockchain-node:bootJar --no-daemon
 


### PR DESCRIPTION
## Summary
- import additional CA certificate into JVM truststore during build
- document absolute path for `BUILD_CA_CERT` in Quick Start guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863b97ca2fc8326ba5fa12c6517361d