### PR TITLE
Add optional Zscaler cert via Docker secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ A lightweight Proof-of-Work blockchain node written in **Java 21** + **Spring Bo
      ```env
      BACKEND_PORT=1002
      FRONTEND_PORT=8892
-     # Optionally trust an additional CA certificate during the Docker build
-    BUILD_CA_CERT=./zscaler.crt
-    ```
-   If `BUILD_CA_CERT` is empty or the file can't be found, the image is built without adding a certificate.
-   `docker-compose` passes `BACKEND_PORT` to the backend container as `SERVER_PORT`.
-   The Docker image exposes this port and defaults to `3333` if not overridden.
+      # Optional certificate to trust during the Docker build
+      BUILD_CA_CERT=./zscaler.crt
+      ```
+    If `BUILD_CA_CERT` is empty or the file can't be found, nothing is imported.
+    Docker BuildKit (`DOCKER_BUILDKIT=1`) must be enabled for the secret mount.
+    `docker-compose` passes `BACKEND_PORT` to the backend container as `SERVER_PORT`.
+    The Docker image exposes this port and defaults to `3333` if not overridden.
 2. **Start the stack:**
    ```bash
    ./gradlew dockerComposeUp
@@ -45,9 +46,9 @@ A lightweight Proof-of-Work blockchain node written in **Java 21** + **Spring Bo
    ./gradlew dockerComposeDown
    ```
 
-### Zertifikat hinterlegen
+### Zertifikat (optional)
 
-Setze die Variable `BUILD_CA_CERT` auf den absoluten Pfad zu deinem
+Setze `BUILD_CA_CERT` auf den absoluten Pfad zu deinem
 Zscaler-Root-Zertifikat **in Unix-Schreibweise**:
 
 Unix / Linux
@@ -60,8 +61,11 @@ Windows (PowerShell)
 setx BUILD_CA_CERT "C:/Users/maierm/zscaler/zscalerwsl.crt"
 ```
 
-Wichtig: Vorwärtsschrägstriche (/) funktionieren auch unter Windows,
-weil `keytool` diese akzeptiert.
+Hinweise:
+
+- Verwende absolute Pfade in **Unix-Schreibweise**, z. B. `C:/Users/maierm/zscaler/zscaler.crt`.
+- Ist `BUILD_CA_CERT` leer, wird nichts importiert.
+- Docker BuildKit (`DOCKER_BUILDKIT=1`) muss aktiviert sein.
 
 ---
 

--- a/blockchain-node/Dockerfile
+++ b/blockchain-node/Dockerfile
@@ -1,33 +1,26 @@
+# syntax=docker/dockerfile:1.4
 # ------------------------------------------------
 # 1) Build Stage: Gradle builds the Spring Boot JAR
 # ------------------------------------------------
 FROM gradle:8.7.0-jdk21 AS build
 WORKDIR /workspace
 
-# Optional certificate to trust during dependency downloads
-ARG BUILD_CA_CERT
-ENV BUILD_CA_CERT=${BUILD_CA_CERT}
-
 # Full project is required for a multi-module build
 COPY . .
 
-# If a custom cert path is provided and exists, install it
-RUN if [ -n "$BUILD_CA_CERT" ] && [ -f "$BUILD_CA_CERT" ]; then \
-      cp "$BUILD_CA_CERT" /usr/local/share/ca-certificates/custom.crt && \
-      update-ca-certificates; \
-    fi
-
-# --- Zertifikat ebenfalls in den JVM-Truststore legen --------------
-RUN if [ -n "$BUILD_CA_CERT" ] && [ -f "$BUILD_CA_CERT" ]; then \
-      keytool -importcert \
-              -alias zscaler \
-              -file "$BUILD_CA_CERT" \
-              -keystore "$JAVA_HOME/lib/security/cacerts" \
-              -storepass changeit \
-              -noprompt \
-              -trustcacerts && \
-      # Symlink, damit Linux-Store und JVM-Store identisch bleiben
-      ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
+# Optionally trust a CA certificate provided via secret
+RUN --mount=type=secret,id=zscaler_cert,required=false \
+    if [ -s /run/secrets/zscaler_cert ]; then \
+        cp /run/secrets/zscaler_cert /usr/local/share/ca-certificates/zscaler.crt && \
+        update-ca-certificates && \
+        keytool -importcert \
+                -alias zscaler \
+                -file /run/secrets/zscaler_cert \
+                -keystore "$JAVA_HOME/lib/security/cacerts" \
+                -storepass changeit -trustcacerts -noprompt && \
+        ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
+    else \
+        echo "→ Kein Zertifikat gefunden – Import übersprungen"; \
     fi
 
 # Build only the node module

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
+secrets:
+  zscaler_cert:
+    file: ${BUILD_CA_CERT:-/dev/null}
+
 services:
   backend:
     build:
       context: .
       dockerfile: blockchain-node/Dockerfile
+      secrets: [zscaler_cert]
       args:
         SERVER_PORT: "${BACKEND_PORT}"
-        BUILD_CA_CERT: "${BUILD_CA_CERT}"
     env_file: .env
     environment:
       NODE_WALLET_PASSWORD: "${NODE_WALLET_PASSWORD}"
@@ -16,6 +20,7 @@ services:
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"
     restart: unless-stopped
+    secrets: [zscaler_cert]
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
- support BuildKit secret for optional CA certificate in `blockchain-node` build
- wire up `docker-compose.yml` secrets
- document optional certificate handling in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6863be2d854c8326aec7cf35bb5114a3