### PR TITLE
Improve truststore import logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Hinweise:
 - Verwende absolute Pfade in **Unix-Schreibweise**, z. B. `C:/Users/maierm/zscaler/zscaler.crt`.
 - Ist `BUILD_CA_CERT` leer, wird nichts importiert.
 - Docker BuildKit (`DOCKER_BUILDKIT=1`) muss aktiviert sein.
+- Beim Docker-Build wird das Zertifikat zuerst mit
+  `keytool -cacerts` in die Standard-Trust-Store importiert. Schlägt das fehl,
+  legt der Build einen beschreibbaren Truststore unter
+  `/etc/ssl/certs/java/cacerts` an und importiert das Zertifikat dort.
 
 ---
 

--- a/blockchain-node/Dockerfile
+++ b/blockchain-node/Dockerfile
@@ -13,12 +13,17 @@ RUN --mount=type=secret,id=zscaler_cert,required=false \
     if [ -s /run/secrets/zscaler_cert ]; then \
         cp /run/secrets/zscaler_cert /usr/local/share/ca-certificates/zscaler.crt && \
         update-ca-certificates && \
-        keytool -importcert \
-                -alias zscaler \
-                -file /run/secrets/zscaler_cert \
-                -keystore "$JAVA_HOME/lib/security/cacerts" \
-                -storepass changeit -trustcacerts -noprompt && \
-        ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
+        if keytool -importcert -alias zscaler -file /run/secrets/zscaler_cert \
+                -cacerts -storepass changeit -trustcacerts -noprompt; then \
+            echo "→ Zertifikat in Standard-cacerts importiert"; \
+        else \
+            echo "→ keytool -cacerts fehlgeschlagen, erstelle beschreibbaren Truststore"; \
+            mkdir -p /etc/ssl/certs/java && \
+            cp "$JAVA_HOME/lib/security/cacerts" /etc/ssl/certs/java/cacerts && \
+            ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts" && \
+            keytool -importcert -alias zscaler -file /run/secrets/zscaler_cert \
+                -keystore /etc/ssl/certs/java/cacerts -storepass changeit -trustcacerts -noprompt; \
+        fi; \
     else \
         echo "→ Kein Zertifikat gefunden – Import übersprungen"; \
     fi


### PR DESCRIPTION
## Summary
- enhance CA import step in `blockchain-node/Dockerfile`
- document trust store fallback in README

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6863c49d8c9c83269c9032b17b1979cd