### PR TITLE
remove NODE_PUBLIC vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Runtime data (blocks, wallet keys) lives in `data/`. Compose reads configuration
    BACKEND_PORT=1002
    FRONTEND_PORT=8892
    ```
+   The backend automatically queries `api.ipify.org` to advertise its public IP
+   to peers.
 2. **Start** – build artifacts and run both services:
    ```bash
    ./gradlew composeUp
@@ -132,6 +134,7 @@ Use different ports and specify peers when launching multiple nodes:
 | 2 | `BACKEND_PORT=1003 NODE_PEERS=localhost:1002 ./gradlew composeUp` |
 
 Start mining on either node and watch both chains converge.
+Each node detects its public host automatically via `api.ipify.org`.
 
 ## Roadmap
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PublicIpService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PublicIpService.java
@@ -1,0 +1,35 @@
+package de.flashyotter.blockchain_node.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+/**
+ * Looks up the node's outward-facing IP address via a simple HTTP request.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PublicIpService {
+
+    private final WebClient webClient;
+
+    /**
+     * @return detected public IP address or {@code null} if the lookup failed
+     */
+    public String fetchPublicIp() {
+        try {
+            return webClient.get()
+                             .uri("https://api.ipify.org")
+                             .retrieve()
+                             .bodyToMono(String.class)
+                             .block(Duration.ofSeconds(5));
+        } catch (Exception e) {
+            log.warn("Public IP lookup failed: {}", e.toString());
+            return null;
+        }
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/NodePropertiesTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/NodePropertiesTest.java
@@ -1,0 +1,23 @@
+package de.flashyotter.blockchain_node.config;
+
+import de.flashyotter.blockchain_node.service.PublicIpService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class NodePropertiesTest {
+
+    @Test
+    void initAddressUsesService() {
+        NodeProperties props = new NodeProperties();
+        PublicIpService svc = mock(PublicIpService.class);
+        when(svc.fetchPublicIp()).thenReturn("203.0.113.9");
+        props.setIpService(svc);
+
+        props.initAddress();
+
+        assertEquals("203.0.113.9", props.getPublicHost());
+        verify(svc).fetchPublicIp();
+    }
+}


### PR DESCRIPTION
## Summary
- drop NODE_PUBLIC_HOST and NODE_PUBLIC_PORT
- always detect the public IP via ipify on startup
- simplify compose setup and README
- update tests for new behaviour

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686545e0db0c83269eef1e7b12d36026