### PR TITLE
Add libp2p feature flag and stub service

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -20,6 +20,12 @@ public class NodeProperties {
     /** Base directory for node data like the ID file. */
     private String dataPath = "data";
 
+    /**
+     * P2P transport mode. Either "legacy" (WebSocket), "libp2p" or "dual" for
+     * both. Defaults to legacy to keep backward compatibility.
+     */
+    private String p2pMode = "legacy";
+
     /** Maximum number of transactions kept in the mempool */
     @Value("${mempool.maxSize:1000}")
     private int mempoolMaxSize = 1000;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -1,0 +1,32 @@
+package de.flashyotter.blockchain_node.p2p.libp2p;
+
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.dto.P2PMessageDto;
+import de.flashyotter.blockchain_node.p2p.Peer;
+import io.libp2p.core.Host;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Libp2pService {
+
+    private final Host host;
+    private final NodeProperties props;
+
+    @PostConstruct
+    public void init() {
+        host.listenAddresses().forEach(a -> log.info("libp2p listening on {}", a));
+    }
+
+    public void broadcast(P2PMessageDto dto) {
+        // TODO implement real transport
+    }
+
+    public void send(Peer peer, P2PMessageDto dto) {
+        // TODO implement real transport
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/P2PBroadcastService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/P2PBroadcastService.java
@@ -8,6 +8,7 @@ import de.flashyotter.blockchain_node.dto.P2PMessageDto;
 import de.flashyotter.blockchain_node.dto.PeerListDto;
 import de.flashyotter.blockchain_node.p2p.Peer;
 import de.flashyotter.blockchain_node.p2p.PeerClient;
+import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +20,7 @@ public class P2PBroadcastService implements P2PBroadcastPort {
 
     private final PeerRegistry registry;
     private final PeerClient   client;
+    private final Libp2pService libp2p;
 
     /* ------------------------------------------------------------------ */
     /* interface implementation                                           */
@@ -49,10 +51,10 @@ public class P2PBroadcastService implements P2PBroadcastPort {
         registry.all().stream()
                 .filter(p -> origin == null || !p.equals(origin)) // avoid echo
                 .forEach(p -> {
-                    try { client.send(p, dto); }
-                    catch (Exception e) {
+                    try { client.send(p, dto); } catch (Exception e) {
                         log.warn("❌  send to {} failed: {}", p, e.getMessage());
                     }
+                    libp2p.send(p, dto);
                 });
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/NodePropertiesTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/NodePropertiesTest.java
@@ -1,0 +1,12 @@
+package de.flashyotter.blockchain_node.config;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NodePropertiesTest {
+    @Test
+    void defaultP2pModeIsLegacy() {
+        NodeProperties props = new NodeProperties();
+        assertEquals("legacy", props.getP2pMode());
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/P2PBroadcastServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/P2PBroadcastServiceTest.java
@@ -22,13 +22,14 @@ class P2PBroadcastServiceTest {
 
     @Mock PeerRegistry registry;
     @Mock PeerClient   client;
+    @Mock de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p;
 
     P2PBroadcastService svc;
 
     @BeforeEach
     void init() {
         MockitoAnnotations.openMocks(this);
-        svc = new P2PBroadcastService(registry, client);
+        svc = new P2PBroadcastService(registry, client, libp2p);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- introduce `p2pMode` setting in `NodeProperties`
- add skeleton `Libp2pService` that exposes placeholders for libp2p messaging
- wire `P2PBroadcastService` to also call `Libp2pService`
- adjust broadcast service tests
- add test for new `p2pMode` property

## Testing
- `./gradlew test -q`
- `./gradlew clean jacocoTestReport -q`


------
https://chatgpt.com/codex/tasks/task_e_6869b0f21494832681206327cee31a99