### PR TITLE
Read runtime config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,22 @@ A lightweight Proof-of-Work blockchain node written in **Java 21** + **Spring Bo
 
 **How to run:**
 
-1. **Set your ports (optional):**
-   - Edit the `.env` file in the project root to set your desired frontend and backend ports:
-     ```env
-     BACKEND_PORT=1002
-     FRONTEND_PORT=8892
-     NODE_LIBP2P_PORT=4001
-     # Optional certificate to trust during the Docker build
-     BUILD_CA_CERT=./zscaler.crt
-      ```
-    If `BUILD_CA_CERT` is empty or the file can't be found, nothing is imported.
-    Docker BuildKit (`DOCKER_BUILDKIT=1`) must be enabled for the secret mount.
-    `docker-compose` passes `BACKEND_PORT` to the backend container as `SERVER_PORT`.
-    The Docker image exposes this port and defaults to `3333` if not overridden.
+1. **Configure the environment:**
+   Create or edit the `.env` file in the project root. Example:
+   ```env
+   BACKEND_PORT=1002
+   FRONTEND_PORT=8892
+   NODE_LIBP2P_PORT=4001
+   NODE_PEERS=
+   NODE_WALLET_PASSWORD=changeMeSuperSecret
+   NODE_JWT_SECRET=myTopSecret
+   # Optional certificate to trust during the Docker build
+   BUILD_CA_CERT=./zscaler.crt
+   ```
+   If `BUILD_CA_CERT` is empty or the file can't be found, nothing is imported.
+   Docker BuildKit (`DOCKER_BUILDKIT=1`) must be enabled for the secret mount.
+   `docker-compose` passes `BACKEND_PORT` to the backend container as `SERVER_PORT`.
+   The Docker image exposes this port and defaults to `3333` if not overridden.
 2. **Start the stack:**
    ```bash
    ./gradlew dockerComposeUp

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -9,6 +9,7 @@ import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 
 @Data
@@ -46,7 +47,12 @@ public class NodeProperties {
     private String walletPassword;
 
     @PostConstruct
-    private void initId() throws IOException {
+    private void init() throws IOException {
+        String peersEnv = System.getenv("NODE_PEERS");
+        if ((peers == null || peers.isEmpty()) && peersEnv != null && !peersEnv.isBlank()) {
+            peers = Arrays.asList(peersEnv.split(","));
+        }
+
         if (id != null && !id.isBlank()) return;
         Path path = Path.of(dataPath, "nodeId");
         if (Files.exists(path)) {

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -12,12 +12,12 @@ server:
   address: 0.0.0.0
   port: ${SERVER_PORT:3333}
 
-node:
-  peers: []
-  data-path: data
-  wallet-password: ${NODE_WALLET_PASSWORD:changeMe}
-  jwt-secret:    ${NODE_JWT_SECRET:changeMeSuperSecret}
-  libp2p-port:   ${NODE_LIBP2P_PORT:4001}
+  node:
+    peers: ${NODE_PEERS:}
+    data-path: data
+    wallet-password: ${NODE_WALLET_PASSWORD:changeMe}
+    jwt-secret:    ${NODE_JWT_SECRET:changeMeSuperSecret}
+    libp2p-port:   ${NODE_LIBP2P_PORT:4001}
 
 wallet:
   store-path: .simple-chain/wallet.p12


### PR DESCRIPTION
## Summary
- load `NODE_PEERS` at runtime if no peers configured
- reference NODE_* variables in `application.yml`
- document example `.env` values in README

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`
- `./gradlew composeUp` *(fails: command 'docker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6112e59c8326b11b6d9d9cec9607