### PR TITLE
Implement peer sync and tests

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
 import de.flashyotter.blockchain_node.p2p.Peer;
+import de.flashyotter.blockchain_node.dto.BlocksDto;
+import de.flashyotter.blockchain_node.dto.GetBlocksDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -14,11 +16,47 @@ public class SyncService {
 
     private final NodeService  node;
     private final Libp2pService libp2p;
+    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER = new com.fasterxml.jackson.databind.ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.module.paramnames.ParameterNamesModule())
+            .addMixIn(blockchain.core.model.Block.class, BlockMixIn.class)
+            .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .findAndRegisterModules();
 
-    /** Currently gossip-based sync is handled by libp2p handlers. */
+    private abstract static class BlockMixIn {
+        @com.fasterxml.jackson.annotation.JsonCreator
+        BlockMixIn(@com.fasterxml.jackson.annotation.JsonProperty("height") int height,
+                   @com.fasterxml.jackson.annotation.JsonProperty("prevHashHex") String prev,
+                   @com.fasterxml.jackson.annotation.JsonProperty("txs") java.util.List<blockchain.core.model.Transaction> txs,
+                   @com.fasterxml.jackson.annotation.JsonProperty("compactBits") int bits,
+                   @com.fasterxml.jackson.annotation.JsonProperty("fixedTimeMillis") long time,
+                   @com.fasterxml.jackson.annotation.JsonProperty("fixedNonce") int nonce) {}
+    }
+
+    /**
+     * Fetch blocks from {@code peer} until no newer blocks are returned.
+     * Each batch is requested via {@link GetBlocksDto} and processed as a
+     * {@link BlocksDto} reply.
+     */
     public Flux<Void> followPeer(Peer peer) {
-        // libp2p streams gossip blocks and transactions automatically
-        return Flux.empty();
+        return Flux.create(sink -> {
+            int height = node.latestBlock().getHeight();
+            while (true) {
+                BlocksDto resp = libp2p.requestBlocks(peer, new GetBlocksDto(height));
+                if (resp.rawBlocks().isEmpty()) {
+                    sink.complete();
+                    break;
+                }
+                resp.rawBlocks().forEach(raw -> {
+                    try {
+                        blockchain.core.model.Block blk = MAPPER.readValue(raw, blockchain.core.model.Block.class);
+                        node.acceptExternalBlock(blk);
+                    } catch (Exception e) {
+                        log.warn("failed to parse block from peer: {}", e.getMessage());
+                    }
+                });
+                height = node.latestBlock().getHeight();
+            }
+        });
     }
 
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SyncServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SyncServiceTest.java
@@ -1,0 +1,79 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import de.flashyotter.blockchain_node.dto.BlocksDto;
+import de.flashyotter.blockchain_node.dto.GetBlocksDto;
+import de.flashyotter.blockchain_node.p2p.Peer;
+import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import blockchain.core.serialization.JsonUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import blockchain.core.model.Transaction;
+
+import java.util.List;
+
+public class SyncServiceTest {
+
+    @Mock
+    NodeService node;
+    @Mock
+    Libp2pService libp2p;
+    SyncService svc;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(blockchain.core.model.Block.class, BlockMixIn.class);
+        mapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        JsonUtils.use(mapper);
+        svc = new SyncService(node, libp2p);
+    }
+
+    private abstract static class BlockMixIn {
+        @JsonCreator
+        BlockMixIn(@JsonProperty("height") int height,
+                   @JsonProperty("prevHashHex") String prev,
+                   @JsonProperty("txs") java.util.List<Transaction> txs,
+                   @JsonProperty("compactBits") int bits,
+                   @JsonProperty("fixedTimeMillis") long time,
+                   @JsonProperty("fixedNonce") int nonce) {}
+    }
+
+    @Test
+    void followPeerRequestsUntilEmpty() {
+        Peer peer = new Peer("h", 1);
+        Block genesis = new Block(0, "g", List.of(new Transaction()), 0);
+        Block b1 = new Block(1, "h1", List.of(new Transaction()), 0);
+        Block b2 = new Block(2, "h2", List.of(new Transaction()), 0);
+
+        when(node.latestBlock()).thenReturn(genesis, b2, b2);
+        String j1 = "{\"height\":1,\"prevHashHex\":\"h1\",\"txs\":[],\"compactBits\":0,\"fixedTimeMillis\":0,\"fixedNonce\":0}";
+        String j2 = "{\"height\":2,\"prevHashHex\":\"h2\",\"txs\":[],\"compactBits\":0,\"fixedTimeMillis\":0,\"fixedNonce\":0}";
+        when(libp2p.requestBlocks(eq(peer), any(GetBlocksDto.class)))
+                .thenReturn(new BlocksDto(List.of(j1, j2)), new BlocksDto(List.of()));
+
+        svc.followPeer(peer).collectList().block();
+
+        ArgumentCaptor<GetBlocksDto> captor = ArgumentCaptor.forClass(GetBlocksDto.class);
+        verify(libp2p, times(2)).requestBlocks(eq(peer), captor.capture());
+        org.junit.jupiter.api.Assertions.assertEquals(
+                java.util.List.of(0, 2),
+                captor.getAllValues().stream().map(GetBlocksDto::fromHeight).toList()
+        );
+        verify(node, times(2)).acceptExternalBlock(any(Block.class));
+    }
+}


### PR DESCRIPTION
## Summary
- implement block synchronization in `SyncService`
- add request/response handling in `Libp2pService`
- create unit test for sync logic

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_686a8a4492688326a6d96db3bee26604