### PR TITLE
Update docs for libp2p transition

### DIFF
--- a/README.md.agent.md
+++ b/README.md.agent.md
@@ -1,1 +1,1 @@
-This README describes how to build and run the demo blockchain node. It documents available REST endpoints, WebSocket message types, and hints for running a private network. Use it as a primer when exploring the project.
+This README describes how to build and run the demo blockchain node. It documents available REST endpoints, libp2p message types, and hints for running a private network. Use it as a primer when exploring the project.

--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -1,12 +1,12 @@
 `blockchain-node` contains the Spring Boot application built on `blockchain-core`.
 
 Important paths under `src/main/java/de/flashyotter/blockchain_node`:
-- `BlockchainNodeApplication.java` – entry point starting the HTTP & WebSocket server.
+- `BlockchainNodeApplication.java` – entry point starting the HTTP server and libp2p host.
 - `bootstrap/StartupInitializer.java` – tasks executed at startup.
-- `config/` – Spring configuration classes (`SecurityConfig`, `WebSocketConfig`, ...).
+- `config/` – Spring configuration classes (`SecurityConfig`, `P2PConfig`, ...).
 - `controller/` – REST controllers for chain, mining, transactions and wallet.
 - `service/` – business logic (`NodeService`, `MiningService`, etc.).
-- `p2p/` – `Peer`, `PeerClient` and `PeerServer` for WebSocket networking.
+- `p2p/` – `Peer`, `PeerClient` and `PeerServer` for libp2p networking.
 - `storage/` – `BlockStore` with LevelDB and in-memory implementations.
 - `wallet/` – wallet and keystore utilities.
 


### PR DESCRIPTION
## Summary
- document libp2p/Kademlia usage in README
- mention NODE_LIBP2P_PORT and NODE_PEERS
- update README agent text
- refresh AGENTS snippet for blockchain-node

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686a8a275bac8326b53969ac939f7c79