### PR TITLE
Add Prometheus metrics

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/mempool/Mempool.java
+++ b/blockchain-core/src/main/java/blockchain/core/mempool/Mempool.java
@@ -78,6 +78,11 @@ public class Mempool {
         }
     }
 
+    /** Current number of transactions in the pool. */
+    public int size() {
+        return pool.size();
+    }
+
     private boolean isSpent(String refId) {
         return pool.values().stream()
                    .map(e -> e.tx)

--- a/blockchain-node/build.gradle
+++ b/blockchain-node/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.projectreactor.netty:reactor-netty-http'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/MetricsConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/MetricsConfig.java
@@ -1,0 +1,30 @@
+package de.flashyotter.blockchain_node.config;
+
+import blockchain.core.consensus.Chain;
+import de.flashyotter.blockchain_node.service.MempoolService;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+@RequiredArgsConstructor
+public class MetricsConfig {
+
+    private final MeterRegistry registry;
+    private final Chain chain;
+    private final MempoolService mempool;
+
+    @PostConstruct
+    void init() {
+        Gauge.builder("node_block_height", chain, c -> c.getLatest().getHeight())
+             .description("Current chain height")
+             .register(registry);
+
+        Gauge.builder("node_mempool_size", mempool, MempoolService::size)
+             .description("Current number of pending transactions")
+             .register(registry);
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MempoolService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/MempoolService.java
@@ -33,4 +33,9 @@ public class MempoolService {
     public void purge(List<Transaction> confirmed) {
         mempool.removeAll(confirmed);
     }
+
+    /** Current number of transactions in the pool. */
+    public int size() {
+        return mempool.size();
+    }
 }

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -6,7 +6,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics
+        include: health,metrics,prometheus
 
 server:
   address: 0.0.0.0

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/MetricsConfigTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/MetricsConfigTest.java
@@ -1,0 +1,61 @@
+package de.flashyotter.blockchain_node.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.consensus.ConsensusParams;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.Wallet;
+import de.flashyotter.blockchain_node.service.MempoolService;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class MetricsConfigTest {
+
+    private Chain chain;
+    private MempoolService mempool;
+    private SimpleMeterRegistry registry;
+
+    @BeforeEach
+    void setup() {
+        chain = new Chain();
+        mempool = new MempoolService(new NodeProperties());
+        registry = new SimpleMeterRegistry();
+        new MetricsConfig(registry, chain, mempool).init();
+    }
+
+    @Test
+    void gaugesReflectChainAndMempool() {
+        Gauge height = registry.find("node_block_height").gauge();
+        Gauge size = registry.find("node_mempool_size").gauge();
+        assertNotNull(height);
+        assertNotNull(size);
+        assertEquals(0.0, height.value());
+        assertEquals(0.0, size.value());
+
+        // add a mined block
+        Wallet miner = new Wallet();
+        Transaction cb = new Transaction(miner.getPublicKey(),
+                ConsensusParams.blockReward(1), "1");
+        Block b1 = new Block(1, chain.getLatest().getHashHex(), List.of(cb),
+                chain.getLatest().getCompactDifficultyBits());
+        b1.mineLocally();
+        chain.addBlock(b1);
+        assertEquals(1.0, height.value());
+
+        // submit a transaction to the mempool
+        String utxoId = cb.getOutputs().get(0).id(cb.calcHashHex(), 0);
+        Transaction tx = new Transaction();
+        tx.getInputs().add(new blockchain.core.model.TxInput(utxoId, new byte[0], miner.getPublicKey()));
+        tx.getOutputs().add(new blockchain.core.model.TxOutput(1.0, new Wallet().getPublicKey()));
+        tx.signInputs(miner.getPrivateKey());
+        mempool.submit(tx, chain.getUtxoSnapshot());
+        assertEquals(1.0, size.value());
+    }
+}


### PR DESCRIPTION
## Summary
- enable micrometer prometheus registry
- expose prometheus actuator endpoint
- track block height and mempool size via gauges
- test custom metrics

## Testing
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_686ad518a49c8326a3c4011e2658d2e2