### PR TITLE
Add HD wallet support using mnemonic

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/crypto/CryptoUtils.java
+++ b/blockchain-core/src/main/java/blockchain/core/crypto/CryptoUtils.java
@@ -20,6 +20,8 @@ import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
 
 import lombok.extern.slf4j.Slf4j;
@@ -126,6 +128,20 @@ public final class CryptoUtils {
         } catch (GeneralSecurityException e) {
             log.error("Public key derivation failed", e);
             throw new RuntimeException("Public key derivation failed", e);
+        }
+    }
+
+    /**
+     * Constructs a secp256k1 private key from the given scalar value.
+     */
+    public static PrivateKey privateKeyFromBigInt(BigInteger d) {
+        try {
+            ECParameterSpec params = ECNamedCurveTable.getParameterSpec("secp256k1");
+            var spec = new ECPrivateKeySpec(d, params);
+            KeyFactory kf = KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            return kf.generatePrivate(spec);
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException("Private key construction failed", e);
         }
     }
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/WalletService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/WalletService.java
@@ -1,11 +1,14 @@
 package de.flashyotter.blockchain_node.wallet;
 
-import java.security.GeneralSecurityException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.util.Map;
-import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import blockchain.core.crypto.AddressUtils;
@@ -13,63 +16,98 @@ import blockchain.core.crypto.CryptoUtils;
 import blockchain.core.model.Transaction;
 import blockchain.core.model.TxOutput;
 import blockchain.core.model.Wallet;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.web3j.crypto.Bip32ECKeyPair;
+import org.web3j.crypto.MnemonicUtils;
+import de.flashyotter.blockchain_node.wallet.KeyStoreProvider;
 
 @Service
 @Slf4j
 public class WalletService {
 
-    private static final String KEY_ALIAS = "simplechain";
+    private static final String META_FILE = "hd-wallet.json";
+    private static final int    HARDENED  = 0x80000000;
 
-    private final KeyStoreProvider store;
+    private final Path            metaPath;
+    private final ObjectMapper    mapper = new ObjectMapper();
+
     @Getter private final Wallet localWallet;
+    @Getter private       String mnemonic;
+    private int nextIndex;
 
-    public WalletService(KeyStoreProvider store) {
-        this.store = store;
-        this.localWallet = loadOrCreate();
+    public WalletService(KeyStoreProvider store,
+                         @Value("${wallet.store-path}") String storePath) {
+        Path ks = Path.of(storePath);
+        if (!ks.isAbsolute()) {
+            ks = Path.of(System.getProperty("user.home"), storePath);
+        }
+        this.metaPath = ks.getParent().resolve(META_FILE);
+        loadOrCreateMeta();
+        this.localWallet = deriveWallet(0);
         log.info("Wallet address → {}", AddressUtils.publicKeyToAddress(localWallet.getPublicKey()));
     }
 
     /* ── persist / restore ─────────────────────────────────────────── */
 
-    private Wallet loadOrCreate() {
-        Optional<PrivateKey> maybePriv;
-        try {
-            maybePriv = store.load(KEY_ALIAS);
-        } catch (GeneralSecurityException e) {
-            log.warn("Private-key load failed: {}", e.getMessage());
-            maybePriv = Optional.empty();
-        }
-
-        if (maybePriv.isPresent()) {
-            PrivateKey priv = maybePriv.get();
-            PublicKey pub;
-            if (store instanceof PkcsKeyStoreProvider ks) {
-                try { pub = ks.loadPublicKey(KEY_ALIAS); }
-                catch (Exception e) {
-                    log.warn("Cert lookup failed – deriving pub-key: {}", e.getMessage());
-                    pub = CryptoUtils.derivePublicKey(priv);
-                }
-            } else {
-                pub = CryptoUtils.derivePublicKey(priv);
+    private void loadOrCreateMeta() {
+        if (Files.exists(metaPath)) {
+            try {
+                var info = mapper.readValue(metaPath.toFile(), HdInfo.class);
+                this.mnemonic = info.mnemonic;
+                this.nextIndex = info.nextIndex;
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read wallet metadata", e);
             }
-            log.info("🔑 Loaded existing wallet");
-            return new Wallet(priv, pub);
+            return;
         }
 
-        Wallet fresh = new Wallet();
-        persist(fresh);
-        log.info("🆕 Generated new wallet");
-        return fresh;
-    }
+        byte[] entropy = new byte[16];
+        new SecureRandom().nextBytes(entropy);
+        this.mnemonic = MnemonicUtils.generateMnemonic(entropy);
+        this.nextIndex = 1; // index 0 reserved for localWallet
 
-    private void persist(Wallet w) {
-        try { store.save(KEY_ALIAS, w.getPrivateKey()); }
-        catch (GeneralSecurityException e) {
-            throw new RuntimeException("Failed to save wallet", e);
+        try {
+            Files.createDirectories(metaPath.getParent());
+            mapper.writeValue(metaPath.toFile(), new HdInfo(mnemonic, nextIndex));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store wallet metadata", e);
         }
     }
+
+    private void persistMeta() {
+        try {
+            mapper.writeValue(metaPath.toFile(), new HdInfo(mnemonic, nextIndex));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store wallet metadata", e);
+        }
+    }
+
+    private Wallet deriveWallet(int index) {
+        byte[] seed = MnemonicUtils.generateSeed(mnemonic, null);
+        Bip32ECKeyPair master = Bip32ECKeyPair.generateKeyPair(seed);
+        int[] path = {
+                44 | HARDENED,
+                0  | HARDENED,
+                0  | HARDENED,
+                0,
+                index
+        };
+        Bip32ECKeyPair key = Bip32ECKeyPair.deriveKeyPair(master, path);
+        PrivateKey priv = CryptoUtils.privateKeyFromBigInt(key.getPrivateKey());
+        PublicKey pub = CryptoUtils.derivePublicKey(priv);
+        return new Wallet(priv, pub);
+    }
+
+    public synchronized Wallet newAddress() {
+        Wallet w = deriveWallet(nextIndex);
+        nextIndex++;
+        persistMeta();
+        return w;
+    }
+
+    private record HdInfo(String mnemonic, int nextIndex) {}
 
     /* ── public API ────────────────────────────────────────────────── */
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/wallet/WalletServiceIntegrationTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/wallet/WalletServiceIntegrationTest.java
@@ -48,4 +48,24 @@ class WalletServiceIntegrationTest {
 
         assertTrue(tx.verifySignatures(), "ECDSA signatures verify");
     }
+
+    @Test
+    void derivesDeterministicAddresses() throws Exception {
+        java.nio.file.Path dir = java.nio.file.Files.createTempDirectory("hdtest");
+        String store = dir.resolve("ks.p12").toString();
+
+        WalletService w1 = new WalletService(new InMemoryKeyStore(), store);
+        String addr0 = AddressUtils.publicKeyToAddress(w1.getLocalWallet().getPublicKey());
+        Wallet firstDerived = w1.newAddress();
+        String addr1 = AddressUtils.publicKeyToAddress(firstDerived.getPublicKey());
+
+        WalletService w2 = new WalletService(new InMemoryKeyStore(), store);
+        String addr0b = AddressUtils.publicKeyToAddress(w2.getLocalWallet().getPublicKey());
+        Wallet secondDerived = w2.newAddress();
+        String addr2 = AddressUtils.publicKeyToAddress(secondDerived.getPublicKey());
+
+        assertEquals(addr0, addr0b);
+        assertNotEquals(addr1, addr2);
+        assertNotEquals(addr0, addr1);
+    }
 }


### PR DESCRIPTION
## Summary
- add helper to create EC private key from BigInteger
- extend WalletService with BIP39 mnemonic and HD key derivation
- persist next derivation index
- verify deterministic address generation in wallet tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686ad9b549188326b78ff44ddd55d771