### PR TITLE
Add periodic snapshots and pruning

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java
+++ b/blockchain-core/src/main/java/blockchain/core/consensus/Chain.java
@@ -100,6 +100,18 @@ public class Chain {
     public Map<String, TxOutput> getUtxoSnapshot()  { return Map.copyOf(utxo.get()); }
     public BigInteger            getTotalWork()     { return cumulativeWork.get(bestTipHash); }
 
+    /** Height at which each coinbase output was created. */
+    public Map<String, Integer> getCoinbaseHeightSnapshot() {
+        return Map.copyOf(coinbaseHeight.get());
+    }
+
+    /** Replaces the UTXO and coinbase height maps with the provided snapshot. */
+    public synchronized void loadUtxoSnapshot(Map<String, TxOutput> utxoMap,
+                                               Map<String, Integer> heights) {
+        utxo.set(new ConcurrentHashMap<>(utxoMap));
+        coinbaseHeight.set(new ConcurrentHashMap<>(heights));
+    }
+
     /* ───────────────────────── Block-Append ───────────────────────── */
     public synchronized void addBlock(Block b) {
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/CoreConsensusConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/CoreConsensusConfig.java
@@ -5,6 +5,7 @@ import blockchain.core.consensus.Chain;
 import blockchain.core.exceptions.BlockchainException;
 import blockchain.core.model.Block;
 import de.flashyotter.blockchain_node.storage.BlockStore;
+import de.flashyotter.blockchain_node.service.SnapshotService;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,7 @@ import java.util.Comparator;
 public class CoreConsensusConfig {
 
     @Bean
-    public Chain chain(BlockStore store) {
+    public Chain chain(BlockStore store, SnapshotService snapshots) {
         Chain chain = new Chain();
 
         java.util.List<Block> blocks = new ArrayList<>();
@@ -35,6 +36,11 @@ public class CoreConsensusConfig {
                 LoggerFactory.getLogger(CoreConsensusConfig.class)
                         .warn("Skipping invalid block {}: {}", b.getHashHex(), e.getMessage());
             }
+        }
+
+        SnapshotService.Snapshot snap = snapshots.loadLatest();
+        if (snap != null && snap.height() == chain.getLatest().getHeight()) {
+            chain.loadUtxoSnapshot(snap.utxo(), snap.coinbase());
         }
 
         return chain;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -55,6 +55,12 @@ public class NodeProperties {
     /** Number of worker threads used for mining */
     private int miningThreads = Runtime.getRuntime().availableProcessors();
 
+    /** Interval for writing UTXO snapshots in seconds */
+    private int snapshotIntervalSec = 300;
+
+    /** How many recent blocks to keep in memory and on disk */
+    private int historyDepth = 1000;
+
     @PostConstruct
     private void init() throws IOException {
         String peersEnv = System.getenv("NODE_PEERS");

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PruningService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PruningService.java
@@ -12,7 +12,7 @@ import reactor.core.scheduler.Schedulers;
 import java.util.List;
 
 /** Periodically prunes old fork data from the in-memory chain. */
-@Service
+@Deprecated
 @RequiredArgsConstructor
 @Slf4j
 public class PruningService {

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SnapshotService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SnapshotService.java
@@ -1,0 +1,100 @@
+package de.flashyotter.blockchain_node.service;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.model.TxOutput;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.storage.BlockStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/** Periodically writes the UTXO set to disk and prunes old blocks. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SnapshotService {
+    private final Chain chain;
+    private final NodeProperties props;
+    private final BlockStore store;
+    private final ObjectMapper mapper;
+
+    public record Snapshot(int height,
+                           Block tip,
+                           Map<String, TxOutput> utxo,
+                           Map<String, Integer> coinbase) {}
+
+    @PostConstruct
+    void start() {
+        Schedulers.boundedElastic().schedule(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(props.getSnapshotIntervalSec() * 1000L);
+                    writeSnapshot();
+                    pruneBlocks();
+                } catch (InterruptedException e) {
+                    return;
+                } catch (Exception e) {
+                    log.warn("Snapshot failed", e);
+                }
+            }
+        });
+    }
+
+    private void writeSnapshot() throws IOException {
+        Path dir = Path.of(props.getDataPath(), "snapshots");
+        Files.createDirectories(dir);
+
+        Block tip = chain.getLatest();
+        Snapshot snap = new Snapshot(
+                tip.getHeight(),
+                tip,
+                chain.getUtxoSnapshot(),
+                chain.getCoinbaseHeightSnapshot()
+        );
+        Path file = dir.resolve(String.format("%07d.json", snap.height()));
+        mapper.writeValue(file.toFile(), snap);
+        log.info("Wrote snapshot {}", file.getFileName());
+    }
+
+    private void pruneBlocks() {
+        List<Block> removed = chain.pruneOldBlocks(props.getHistoryDepth());
+        for (Block b : removed) {
+            store.save(b);
+        }
+        if (!removed.isEmpty()) {
+            log.info("Pruned {} blocks from DAG", removed.size());
+        }
+    }
+
+    /** Loads the most recent snapshot if present. */
+    public Snapshot loadLatest() {
+        Path dir = Path.of(props.getDataPath(), "snapshots");
+        if (!Files.isDirectory(dir)) return null;
+        try {
+            return Files.list(dir)
+                    .filter(p -> p.toString().endsWith(".json"))
+                    .max(Comparator.naturalOrder())
+                    .map(p -> {
+                        try {
+                            return mapper.readValue(p.toFile(), Snapshot.class);
+                        } catch (IOException e) {
+                            log.warn("Failed to read snapshot {}", p, e);
+                            return null;
+                        }
+                    }).orElse(null);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
@@ -17,6 +17,8 @@ import blockchain.core.model.Wallet;
 import blockchain.core.serialization.JsonUtils;
 import de.flashyotter.blockchain_node.storage.InMemoryBlockStore;
 import de.flashyotter.blockchain_node.storage.BlockStore;
+import de.flashyotter.blockchain_node.service.SnapshotService;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 
 class ChainBootstrapTest {
 
@@ -39,7 +41,9 @@ class ChainBootstrapTest {
     }
 
     private Chain build(BlockStore store) {
-        return new CoreConsensusConfig().chain(store);
+        SnapshotService svc = new SnapshotService(
+                new Chain(), new NodeProperties(), store, mapper);
+        return new CoreConsensusConfig().chain(store, svc);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add snapshot interval and history depth properties
- expose coinbase height map and allow reloading UTXO snapshots
- write new `SnapshotService` that saves snapshots and prunes old blocks
- load the latest snapshot during chain bootstrap
- update tests for snapshot service

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686adfc4c9fc8326806cfb17a2505b7c