### PR TITLE
Refactor service loops to scheduled tasks

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/BlockchainNodeApplication.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/BlockchainNodeApplication.java
@@ -2,9 +2,11 @@ package de.flashyotter.blockchain_node;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
+@EnableScheduling
 public class BlockchainNodeApplication {
 
 	public static void main(String[] args) {

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -1,9 +1,9 @@
 package de.flashyotter.blockchain_node.service;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import de.flashyotter.blockchain_node.p2p.Peer;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
 // blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -16,17 +16,14 @@ public class DiscoveryLoop {
     private final KademliaService kademlia;
     private final de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p;
 
-    @PostConstruct
-    void loop() {
-        reactor.core.scheduler.Schedulers.boundedElastic().schedule(() -> {
-            while (true) {
-                try {
-                    Peer p = reg.pending().take();
-                    kademlia.store(p);
-                    sync.followPeer(p).subscribe();
-                    libp2p.send(p, new de.flashyotter.blockchain_node.dto.FindNodeDto(kademlia.selfId()));
-                } catch (InterruptedException ignored) { }
-            }
-        });
+    @Scheduled(fixedDelay = 1000)
+    void pollPendingPeers() {
+        Peer p;
+        while ((p = reg.pending().poll()) != null) {
+            kademlia.store(p);
+            sync.followPeer(p).subscribe();
+            libp2p.send(p, new de.flashyotter.blockchain_node.dto.FindNodeDto(kademlia.selfId()));
+        }
     }
 }
+

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/DiscoveryLoopSchedulingTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/DiscoveryLoopSchedulingTest.java
@@ -1,0 +1,75 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+
+import de.flashyotter.blockchain_node.p2p.Peer;
+
+class DiscoveryLoopSchedulingTest {
+
+    private AnnotationConfigApplicationContext ctx;
+    private PeerRegistry reg;
+    private KademliaService kademlia;
+
+    @BeforeEach
+    void setUp() {
+        reg = new PeerRegistry();
+        SyncService sync = mock(SyncService.class);
+        kademlia = mock(KademliaService.class);
+        de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p = mock(de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService.class);
+
+        DiscoveryLoop target = new DiscoveryLoop(reg, sync, kademlia, libp2p);
+        DiscoveryLoop spySvc = spy(target);
+
+        ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(PeerRegistry.class, () -> reg);
+        ctx.registerBean(SyncService.class, () -> sync);
+        ctx.registerBean(KademliaService.class, () -> kademlia);
+        ctx.registerBean(de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService.class, () -> libp2p);
+        ctx.registerBean(DiscoveryLoop.class, () -> spySvc);
+        ctx.registerBean(ScheduledAnnotationBeanPostProcessor.class);
+        ctx.refresh();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ctx.close();
+    }
+
+    @Test
+    void pollingStopsAfterShutdown() throws Exception {
+        Peer p = new Peer("h", 1);
+        reg.pending().offer(p);
+
+        await().atMost(Duration.ofSeconds(2))
+              .untilAsserted(() -> verify(kademlia, atLeastOnce()).store(p));
+
+        long before = mockingDetails(kademlia).getInvocations().stream()
+                .filter(inv -> inv.getMethod().getName().equals("store"))
+                .count();
+
+        ctx.close();
+        reg.pending().offer(new Peer("x", 1));
+        Thread.sleep(1500);
+
+        long after = mockingDetails(kademlia).getInvocations().stream()
+                .filter(inv -> inv.getMethod().getName().equals("store"))
+                .count();
+
+        assertEquals(before, after, "discovery loop should stop after context close");
+    }
+}
+

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceSchedulingTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceSchedulingTest.java
@@ -1,0 +1,92 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.storage.BlockStore;
+
+class SnapshotServiceSchedulingTest {
+
+    @TempDir
+    Path temp;
+
+    private AnnotationConfigApplicationContext ctx;
+    private SnapshotService spySvc;
+
+    @BeforeEach
+    void setUp() {
+        NodeProperties props = new NodeProperties();
+        props.setDataPath(temp.toString());
+        props.setSnapshotIntervalSec(1);
+
+        Chain chain = mock(Chain.class);
+        Block genesis = new Block(0, "g", List.of(new Transaction()), 0);
+        org.mockito.Mockito.when(chain.getLatest()).thenReturn(genesis);
+        org.mockito.Mockito.when(chain.getUtxoSnapshot()).thenReturn(Map.of());
+        org.mockito.Mockito.when(chain.getCoinbaseHeightSnapshot()).thenReturn(Map.of());
+
+        BlockStore store = mock(BlockStore.class);
+        ObjectMapper mapper = new ObjectMapper();
+
+        SnapshotService target = new SnapshotService(chain, props, store, mapper);
+        spySvc = spy(target);
+
+        ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(NodeProperties.class, () -> props);
+        ctx.registerBean(Chain.class, () -> chain);
+        ctx.registerBean(BlockStore.class, () -> store);
+        ctx.registerBean(ObjectMapper.class, () -> mapper);
+        ctx.registerBean(SnapshotService.class, () -> spySvc);
+        ctx.registerBean(ScheduledAnnotationBeanPostProcessor.class);
+        ctx.refresh();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ctx.close();
+    }
+
+    @Test
+    void taskStopsAfterContextShutdown() throws Exception {
+        await().atMost(Duration.ofSeconds(2))
+              .untilAsserted(() -> verify(spySvc, atLeastOnce()).snapshotTask());
+
+        long before = mockingDetails(spySvc).getInvocations().stream()
+                .filter(inv -> inv.getMethod().getName().equals("snapshotTask"))
+                .count();
+
+        ctx.close();
+
+        Thread.sleep(1500);
+
+        long after = mockingDetails(spySvc).getInvocations().stream()
+                .filter(inv -> inv.getMethod().getName().equals("snapshotTask"))
+                .count();
+
+        assertEquals(before, after, "scheduled task should stop after context close");
+    }
+}
+


### PR DESCRIPTION
## Summary
- enable scheduling in the Spring Boot application
- replace busy loops in DiscoveryLoop, SnapshotService and PruningService with `@Scheduled` methods
- add unit tests verifying that scheduled tasks stop after the application context shuts down

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686be4c77a7c8326a88e3d9cc7f1c9f3