### PR TITLE
Add metrics for block propagation and snapshots

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/MetricsConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/MetricsConfig.java
@@ -2,8 +2,10 @@ package de.flashyotter.blockchain_node.config;
 
 import blockchain.core.consensus.Chain;
 import de.flashyotter.blockchain_node.service.MempoolService;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +19,13 @@ public class MetricsConfig {
     private final Chain chain;
     private final MempoolService mempool;
 
+    /** Time it takes to broadcast a block to all peers. */
+    public static final String BLOCK_BROADCAST_TIME = "node_block_broadcast_time";
+    /** Count of successful UTXO snapshots. */
+    public static final String SNAPSHOT_SUCCESS = "snapshot_success_total";
+    /** Count of failed UTXO snapshots. */
+    public static final String SNAPSHOT_FAILURE = "snapshot_failure_total";
+
     @PostConstruct
     void init() {
         Gauge.builder("node_block_height", chain, c -> c.getLatest().getHeight())
@@ -26,5 +35,17 @@ public class MetricsConfig {
         Gauge.builder("node_mempool_size", mempool, MempoolService::size)
              .description("Current number of pending transactions")
              .register(registry);
+
+        Timer.builder(BLOCK_BROADCAST_TIME)
+             .description("Time to broadcast a block to all peers")
+             .register(registry);
+
+        Counter.builder(SNAPSHOT_SUCCESS)
+               .description("Number of successful snapshots")
+               .register(registry);
+
+        Counter.builder(SNAPSHOT_FAILURE)
+               .description("Number of failed snapshots")
+               .register(registry);
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
@@ -42,7 +42,7 @@ class ChainBootstrapTest {
 
     private Chain build(BlockStore store) {
         SnapshotService svc = new SnapshotService(
-                new Chain(), new NodeProperties(), store, mapper);
+                new Chain(), new NodeProperties(), store, mapper, new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
         return new CoreConsensusConfig().chain(store, svc);
     }
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/MetricsConfigTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/MetricsConfigTest.java
@@ -58,4 +58,11 @@ class MetricsConfigTest {
         mempool.submit(tx, chain.getUtxoSnapshot());
         assertEquals(1.0, size.value());
     }
+
+    @Test
+    void additionalMetricsPresent() {
+        assertNotNull(registry.find("node_block_broadcast_time").timer());
+        assertNotNull(registry.find("snapshot_success_total").counter());
+        assertNotNull(registry.find("snapshot_failure_total").counter());
+    }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceMetricsTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceMetricsTest.java
@@ -1,0 +1,67 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.storage.BlockStore;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class SnapshotServiceMetricsTest {
+
+    @TempDir
+    Path temp;
+
+    private SimpleMeterRegistry registry;
+    private SnapshotService svc;
+    private Chain chain;
+    private NodeProperties props;
+
+    @BeforeEach
+    void setUp() {
+        props = new NodeProperties();
+        props.setDataPath(temp.toString());
+
+        chain = mock(Chain.class);
+        Block genesis = new Block(0, "g", List.of(new Transaction()), 0);
+        when(chain.getLatest()).thenReturn(genesis);
+        when(chain.getUtxoSnapshot()).thenReturn(Map.of());
+        when(chain.getCoinbaseHeightSnapshot()).thenReturn(Map.of());
+
+        BlockStore store = mock(BlockStore.class);
+        registry = new SimpleMeterRegistry();
+        svc = new SnapshotService(chain, props, store, new ObjectMapper(), registry);
+    }
+
+    @Test
+    void successIncrementsCounter() {
+        svc.snapshotTask();
+        assertEquals(1, registry.get("snapshot_success_total").counter().count());
+    }
+
+    @Test
+    void failureIncrementsCounter() throws Exception {
+        ObjectMapper failingMapper = org.mockito.Mockito.mock(ObjectMapper.class);
+        doThrow(new IOException()).when(failingMapper)
+                .writeValue(org.mockito.ArgumentMatchers.any(java.io.File.class), org.mockito.ArgumentMatchers.any());
+        SnapshotService failing = new SnapshotService(chain, props, mock(BlockStore.class), failingMapper, registry);
+        failing.snapshotTask();
+        assertEquals(1, registry.get("snapshot_failure_total").counter().count());
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceSchedulingTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceSchedulingTest.java
@@ -50,8 +50,9 @@ class SnapshotServiceSchedulingTest {
 
         BlockStore store = mock(BlockStore.class);
         ObjectMapper mapper = new ObjectMapper();
+        io.micrometer.core.instrument.simple.SimpleMeterRegistry metrics = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
-        SnapshotService target = new SnapshotService(chain, props, store, mapper);
+        SnapshotService target = new SnapshotService(chain, props, store, mapper, metrics);
         spySvc = spy(target);
 
         ctx = new AnnotationConfigApplicationContext();
@@ -59,6 +60,7 @@ class SnapshotServiceSchedulingTest {
         ctx.registerBean(Chain.class, () -> chain);
         ctx.registerBean(BlockStore.class, () -> store);
         ctx.registerBean(ObjectMapper.class, () -> mapper);
+        ctx.registerBean(io.micrometer.core.instrument.MeterRegistry.class, () -> metrics);
         ctx.registerBean(SnapshotService.class, () -> spySvc);
         ctx.registerBean(ScheduledAnnotationBeanPostProcessor.class);
         ctx.refresh();


### PR DESCRIPTION
## Summary
- extend `MetricsConfig` with timer and counters for block propagation time and snapshot outcomes
- update `P2PBroadcastService` to measure block broadcast duration and log completion
- record snapshot success/failure in `SnapshotService`
- adapt tests for new constructors and metrics
- add new `SnapshotServiceMetricsTest` to validate counters

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_686bf4f05104832694fa9bf7a1f597d9