### PR TITLE
Add atomic snapshot writing with retries

### DIFF
--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceRetryTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceRetryTest.java
@@ -1,0 +1,60 @@
+package de.flashyotter.blockchain_node.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.storage.BlockStore;
+
+class SnapshotServiceRetryTest {
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void retryOnFirstFailure() throws Exception {
+        NodeProperties props = new NodeProperties();
+        props.setDataPath(temp.toString());
+
+        Chain chain = Mockito.mock(Chain.class);
+        Block genesis = new Block(0, "g", List.of(new Transaction()), 0);
+        Mockito.when(chain.getLatest()).thenReturn(genesis);
+        Mockito.when(chain.getUtxoSnapshot()).thenReturn(Map.of());
+        Mockito.when(chain.getCoinbaseHeightSnapshot()).thenReturn(Map.of());
+        Mockito.when(chain.pruneOldBlocks(Mockito.anyInt())).thenReturn(List.of());
+
+        BlockStore store = Mockito.mock(BlockStore.class);
+
+        ObjectMapper mapper = Mockito.spy(new ObjectMapper());
+        AtomicInteger calls = new AtomicInteger();
+        Mockito.doAnswer(inv -> {
+            if (calls.getAndIncrement() == 0) {
+                throw new IOException("boom");
+            }
+            return inv.callRealMethod();
+        }).when(mapper).writeValue(Mockito.any(File.class), Mockito.any());
+
+        SnapshotService svc = new SnapshotService(chain, props, store, mapper);
+        svc.snapshotTask();
+
+        assertEquals(2, calls.get(), "should retry once");
+        long files = Files.list(temp.resolve("snapshots")).count();
+        assertEquals(1, files, "snapshot file created");
+    }
+}


### PR DESCRIPTION
## Summary
- write snapshot files atomically via temp file and `Files.move`
- retry snapshot creation up to three times on failure
- test retry logic in `SnapshotService`

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_686bf54fcfd483269a81a2781198ae15