### PR TITLE
Add wallet send validation

### DIFF
--- a/blockchain-node/build.gradle
+++ b/blockchain-node/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.projectreactor.netty:reactor-netty-http'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/WalletController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/WalletController.java
@@ -8,6 +8,7 @@ import de.flashyotter.blockchain_node.dto.WalletInfoDto;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.wallet.WalletService;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,7 +30,7 @@ public class WalletController {
     private final NodeService   node;
 
     @PostMapping("/send")
-    public Transaction send(@RequestBody SendFundsDto dto) {
+    public Transaction send(@RequestBody @Valid SendFundsDto dto) {
         // Create a transaction consuming UTXOs and producing outputs (including change)
         Transaction tx = wallet.createTx(
             dto.recipient(),

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/SendFundsDto.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/SendFundsDto.java
@@ -1,9 +1,15 @@
 package de.flashyotter.blockchain_node.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
 /**
  * Payload for POST /api/wallet/send.
  *
  * @param recipient base64-encoded EC-public-key
  * @param amount    coins to transfer
  */
-public record SendFundsDto(String recipient, double amount) {}
+public record SendFundsDto(
+    @NotBlank String recipient,
+    @Positive double amount
+) {}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/WalletControllerTest.java
@@ -81,6 +81,26 @@ class WalletControllerTest {
     }
 
     @Test
+    void invalidAddress() throws Exception {
+        SendFundsDto dto = new SendFundsDto("", 1.0);
+
+        mvc.perform(post("/api/wallet/send")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(dto)))
+           .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void negativeAmount() throws Exception {
+        SendFundsDto dto = new SendFundsDto("addr1", -1.0);
+
+        mvc.perform(post("/api/wallet/send")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(dto)))
+           .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void historyEndpoint() throws Exception {
         Transaction tx = new Transaction();
         when(nodeSvc.walletHistory("addr1", 5)).thenReturn(List.of(tx));


### PR DESCRIPTION
## Summary
- enforce validation on SendFundsDto using Bean Validation
- wire validation into WalletController
- add tests for invalid wallet send requests
- include spring-boot-starter-validation dependency

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_686bf56ac8d08326a0f7d0ffc12132c8