### PR TITLE
Configurable genesis keystore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,19 @@ NODE_JWT_SECRET=myTopSecret
 NODE_MINING_THREADS=4               # 0 → auto-detect
 NODE_SNAPSHOT_INTERVAL_SEC=300
 NODE_HISTORY_DEPTH=1000
+GENESIS_KEYSTORE_PATH=
 BUILD_CA_CERT=
+
+Create a PKCS#12 keystore containing the private key used for the genesis block
+and point `GENESIS_KEYSTORE_PATH` to it. Example using OpenSSL:
+
+```bash
+openssl ecparam -genkey -name secp256k1 -noout -out genesis.key
+openssl req -new -x509 -key genesis.key -out genesis.crt -subj "/CN=Genesis"
+openssl pkcs12 -export -out genesis.p12 -inkey genesis.key -in genesis.crt -nodes -password pass:
+```
+
+Use the absolute path to `genesis.p12` in the environment variable.
 
 ### 2. Run
 

--- a/blockchain-core/src/test/java/simple/blockchain/consensus/GenesisWalletLoadTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/consensus/GenesisWalletLoadTest.java
@@ -1,0 +1,72 @@
+package simple.blockchain.consensus;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.crypto.AddressUtils;
+import blockchain.core.model.TxOutput;
+import blockchain.core.model.Wallet;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GenesisWalletLoadTest {
+    @AfterEach
+    void reset() {
+        Chain.loadGenesisWallet(null);
+    }
+
+    @Test
+    void genesisWalletLoadedFromKeystore() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        Path ksFile = Files.createTempFile("genesis", ".p12");
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "BC");
+        kpg.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom());
+        KeyPair kp = kpg.generateKeyPair();
+
+        X500Name dn = new X500Name("CN=Genesis");
+        BigInteger serial = BigInteger.ONE;
+        Date now = new Date();
+        var builder = new JcaX509v3CertificateBuilder(dn, serial, now,
+                new Date(now.getTime() + 86400000L), dn, kp.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA")
+                .setProvider("BC").build(kp.getPrivate());
+        X509Certificate cert = new JcaX509CertificateConverter()
+                .setProvider("BC").getCertificate(builder.build(signer));
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, new char[0]);
+        ks.setKeyEntry("g", kp.getPrivate(), new char[0], new java.security.cert.Certificate[]{cert});
+        try (OutputStream out = Files.newOutputStream(ksFile)) {
+            ks.store(out, new char[0]);
+        }
+
+        Chain.loadGenesisWallet(ksFile);
+        Chain chain = new Chain();
+
+        String addr = AddressUtils.publicKeyToAddress(kp.getPublic());
+        Map<String, TxOutput> utxo = chain.getUtxoSnapshot();
+        assertEquals(1, utxo.size());
+        assertEquals(addr, utxo.values().iterator().next().recipientAddress());
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/CoreConsensusConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/CoreConsensusConfig.java
@@ -6,6 +6,8 @@ import blockchain.core.exceptions.BlockchainException;
 import blockchain.core.model.Block;
 import de.flashyotter.blockchain_node.storage.BlockStore;
 import de.flashyotter.blockchain_node.service.SnapshotService;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import java.nio.file.Path;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +22,10 @@ import java.util.Comparator;
 public class CoreConsensusConfig {
 
     @Bean
-    public Chain chain(BlockStore store, SnapshotService snapshots) {
+    public Chain chain(BlockStore store, SnapshotService snapshots, NodeProperties props) {
+        if (props.getGenesisKeystore() != null && !props.getGenesisKeystore().isBlank()) {
+            blockchain.core.consensus.Chain.loadGenesisWallet(java.nio.file.Path.of(props.getGenesisKeystore()));
+        }
         Chain chain = new Chain();
 
         java.util.List<Block> blocks = new ArrayList<>();

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java
@@ -49,6 +49,9 @@ public class NodeProperties {
      */
     private String walletPassword;
 
+    /** Path to the PKCS#12 keystore containing the genesis key. */
+    private String genesisKeystore;
+
     /** Shared secret used to sign and verify JWT tokens. */
     private String jwtSecret = "changeMeSuperSecret";
 

--- a/blockchain-node/src/main/resources/application-test.yml
+++ b/blockchain-node/src/main/resources/application-test.yml
@@ -1,6 +1,7 @@
 node:
   wallet-password: test
   data-path: data
+  genesis-keystore:
 
 wallet:
   store-path: .simple-chain/wallet.p12

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -16,6 +16,7 @@ node:
   peers: ${NODE_PEERS:}
   data-path: data
   wallet-password: ${NODE_WALLET_PASSWORD:changeMe}
+  genesis-keystore: ${GENESIS_KEYSTORE_PATH:}
   jwt-secret:    ${NODE_JWT_SECRET:changeMeSuperSecret}
   libp2p-port:   ${NODE_LIBP2P_PORT:4001}
   p2p-mode: ${NODE_P2P_MODE:legacy}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/config/ChainBootstrapTest.java
@@ -41,9 +41,10 @@ class ChainBootstrapTest {
     }
 
     private Chain build(BlockStore store) {
+        NodeProperties props = new NodeProperties();
         SnapshotService svc = new SnapshotService(
-                new Chain(), new NodeProperties(), store, mapper);
-        return new CoreConsensusConfig().chain(store, svc);
+                new Chain(), props, store, mapper);
+        return new CoreConsensusConfig().chain(store, svc, props);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow loading genesis wallet from external keystore
- configure keystore path via `NodeProperties`
- adapt consensus bootstrap to use new wallet
- document how to generate the keystore
- test genesis wallet loading

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_686bf4ac247c83269c265373866cfd93