### PR TITLE
Add persistent LevelDB block store

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ NODE_SNAPSHOT_INTERVAL_SEC=300
 NODE_HISTORY_DEPTH=1000
 BUILD_CA_CERT=
 
+Blocks are kept in a LevelDB database under `${NODE_DATA_PATH}/blocks`. Mount
+this directory when running the Docker image so the chain persists across
+restarts.
+
 ### 2. Run
 
 ./gradlew dockerComposeUp
@@ -78,7 +82,9 @@ This builds the backend, UI and starts both containers. Point your browser to ht
 
 ### Multiple nodes
 
-To run several nodes on one host give each instance its own data and wallet folder. Map these directories under `backend`:
+To run several nodes on one host give each instance its own data and wallet
+folder. Map these directories under `backend` so the LevelDB store stays
+persistent:
 
 ```yaml
 volumes:

--- a/blockchain-core/src/main/java/blockchain/core/model/Block.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/Block.java
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
  * Mining / PoW live entirely in the header.
  */
 @Getter @Slf4j
-public class Block {
+public class Block implements java.io.Serializable {
 
     private final BlockHeader       header;
     private final List<Transaction> txList;

--- a/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
@@ -11,7 +11,7 @@ import blockchain.core.crypto.HashingUtils;
  * <p>
  * Hash = SHA-256(height ‖ prevHash ‖ time ‖ nonce ‖ merkleRoot)
  */
-public final class BlockHeader {
+public final class BlockHeader implements java.io.Serializable {
 
     /* consensus-critical fields  */
     public final int    height;

--- a/blockchain-core/src/main/java/blockchain/core/model/Transaction.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/Transaction.java
@@ -9,7 +9,7 @@ import blockchain.core.crypto.CryptoUtils;
 import blockchain.core.crypto.HashingUtils;
 
 /** Mutable until signatures are applied, then effectively frozen. */
-public class Transaction {
+public class Transaction implements java.io.Serializable {
 
     private final List<TxInput>  inputs  = new ArrayList<>();
     private final List<TxOutput> outputs = new ArrayList<>();

--- a/blockchain-core/src/main/java/blockchain/core/model/TxInput.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/TxInput.java
@@ -9,7 +9,7 @@ import java.security.PublicKey;
  * References an existing UTXO to be spent.
  */
 @Data @AllArgsConstructor
-public class TxInput {
+public class TxInput implements java.io.Serializable {
     private String    referencedOutputId;   // UTXO id being spent
     private byte[]    signature;            // ECDSA over referencedOutputId
     private PublicKey sender;               // owner of the UTXO

--- a/blockchain-core/src/main/java/blockchain/core/model/TxOutput.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/TxOutput.java
@@ -4,7 +4,7 @@ import blockchain.core.crypto.AddressUtils;
 
 import java.security.PublicKey;
 
-public record TxOutput(double value, String recipientAddress) {
+public record TxOutput(double value, String recipientAddress) implements java.io.Serializable {
 
     /** Helper so tests (and older code) that still pass a PublicKey keep compiling */
     public TxOutput(double value, PublicKey recipient) {

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStore.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStore.java
@@ -1,0 +1,97 @@
+package de.flashyotter.blockchain_node.storage;
+
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.serialization.JsonUtils;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import jakarta.annotation.PreDestroy;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.Options;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
+
+/** Persistent LevelDB-based BlockStore. */
+@Component
+@Primary
+public class LevelDbBlockStore implements BlockStore, AutoCloseable {
+    private final DB db;
+
+    public LevelDbBlockStore(NodeProperties props) {
+        try {
+            Path dir = Path.of(props.getDataPath(), "blocks");
+            Files.createDirectories(dir);
+            Options options = new Options();
+            options.createIfMissing(true);
+            this.db = factory.open(dir.toFile(), options);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to open LevelDB", e);
+        }
+    }
+
+    @Override
+    public void save(Block b) {
+        db.put(b.getHashHex().getBytes(StandardCharsets.UTF_8), encode(b));
+    }
+
+    @Override
+    public Block findByHash(String hash) {
+        byte[] data = db.get(hash.getBytes(StandardCharsets.UTF_8));
+        if (data == null) return null;
+        return decode(data);
+    }
+
+    @Override
+    public Iterable<Block> loadAll() {
+        List<Block> blocks = new ArrayList<>();
+        try (DBIterator it = db.iterator()) {
+            for (it.seekToFirst(); it.hasNext(); it.next()) {
+                Map.Entry<byte[], byte[]> entry = it.peekNext();
+                blocks.add(decode(entry.getValue()));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to iterate DB", e);
+        }
+        return blocks;
+    }
+
+    private byte[] encode(Block b) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(b);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not serialize Block", e);
+        }
+    }
+
+    private Block decode(byte[] bytes) {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+             ObjectInputStream ois = new ObjectInputStream(bais)) {
+            return (Block) ois.readObject();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not deserialize Block", e);
+        }
+    }
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        db.close();
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStoreTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStoreTest.java
@@ -1,0 +1,73 @@
+package de.flashyotter.blockchain_node.storage;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.model.Block;
+import blockchain.core.serialization.JsonUtils;
+import de.flashyotter.blockchain_node.config.JacksonConfig;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LevelDbBlockStoreTest {
+
+    @BeforeAll
+    static void initMapper() {
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        mapper.registerModule(new JacksonConfig().publicKeyModule());
+        JsonUtils.use(mapper);
+    }
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void blockPersistsAcrossRestart() throws Exception {
+        NodeProperties props = new NodeProperties();
+        props.setDataPath(temp.toString());
+
+        Chain chain = new Chain();
+        Block genesis = chain.getLatest();
+
+        LevelDbBlockStore store = new LevelDbBlockStore(props);
+        store.save(genesis);
+        store.close();
+
+        LevelDbBlockStore reopened = new LevelDbBlockStore(props);
+        Block loaded = reopened.findByHash(genesis.getHashHex());
+        reopened.close();
+
+        assertNotNull(loaded);
+        assertEquals(genesis.getHashHex(), loaded.getHashHex());
+    }
+
+    @Test
+    void loadAllAfterRestartReturnsBlocks() throws Exception {
+        NodeProperties props = new NodeProperties();
+        props.setDataPath(temp.toString());
+
+        Chain chain = new Chain();
+        Block genesis = chain.getLatest();
+
+        LevelDbBlockStore first = new LevelDbBlockStore(props);
+        first.save(genesis);
+        first.close();
+
+        LevelDbBlockStore second = new LevelDbBlockStore(props);
+        List<Block> blocks = new ArrayList<>();
+        for (Block b : second.loadAll()) {
+            blocks.add(b);
+        }
+        second.close();
+
+        assertEquals(1, blocks.size());
+        assertEquals(genesis.getHashHex(), blocks.get(0).getHashHex());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LevelDbBlockStore` that saves blocks in `${NODE_DATA_PATH}/blocks` via LevelDB
- mark core model classes as `Serializable` so they can be stored using Java serialization
- register `LevelDbBlockStore` as the primary `BlockStore`
- test persistence across restarts
- document data directory usage and volume mounting in README

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686c2bc23bcc8326b8f98a8ca57f4dec