### PR TITLE
Implement public address handshake via libp2p AutoNAT

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
@@ -11,6 +11,10 @@ package de.flashyotter.blockchain_node.dto;
  * @param nodeId          arbitrary, human-friendly identifier
  * @param protocolVersion semantic protocol version (major.minor.patch)
  * @param listenPort      TCP port the node is accepting peer connections on
+ * @param publicAddr      multiaddress observed via AutoNAT
  */
-public record HandshakeDto(String nodeId, String protocolVersion, int listenPort)
+public record HandshakeDto(String nodeId,
+                           String protocolVersion,
+                           int listenPort,
+                           String publicAddr)
         implements P2PMessageDto { }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -15,6 +15,7 @@ public class DiscoveryLoop {
     private final SyncService    sync;
     private final KademliaService kademlia;
     private final de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p;
+    private final de.flashyotter.blockchain_node.config.NodeProperties props;
 
     @Scheduled(fixedDelay = 1000)
     void pollPendingPeers() {
@@ -23,6 +24,11 @@ public class DiscoveryLoop {
             kademlia.store(p);
             sync.followPeer(p).subscribe();
             libp2p.send(p, new de.flashyotter.blockchain_node.dto.FindNodeDto(kademlia.selfId()));
+            libp2p.send(p, new de.flashyotter.blockchain_node.dto.HandshakeDto(
+                    kademlia.selfId(),
+                    libp2p.protocolVersion(),
+                    props.getLibp2pPort(),
+                    libp2p.getPublicAddr()));
         }
     }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -35,6 +35,11 @@ public class PeerService {
                     syncService.followPeer(p).subscribe();
                     // bootstrap discovery via kademlia
                     libp2p.send(p, new de.flashyotter.blockchain_node.dto.FindNodeDto(kademlia.selfId()));
+                    libp2p.send(p, new de.flashyotter.blockchain_node.dto.HandshakeDto(
+                            props.getId(),
+                            libp2p.protocolVersion(),
+                            props.getLibp2pPort(),
+                            libp2p.getPublicAddr()));
                 });
 
         broadcaster.broadcastPeerList();

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
@@ -41,7 +41,7 @@ class Libp2pHandshakeTest {
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         ByteBuf buf = Unpooled.copiedBuffer(new ObjectMapper()
-                .writeValueAsString(new HandshakeDto("x","0.0.1",0)), StandardCharsets.UTF_8);
+                .writeValueAsString(new HandshakeDto("x","0.0.1",0,"/ip4/1.1.1.1/tcp/1")), StandardCharsets.UTF_8);
         when(ctx.close()).thenReturn(null);
 
         var method = cls.getDeclaredMethod("messageReceived", ChannelHandlerContext.class, ByteBuf.class);
@@ -72,7 +72,7 @@ class Libp2pHandshakeTest {
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         ByteBuf buf = Unpooled.copiedBuffer(new ObjectMapper()
-                .writeValueAsString(new HandshakeDto("x","1.0.0",0)), StandardCharsets.UTF_8);
+                .writeValueAsString(new HandshakeDto("x","1.0.0",0,"/ip4/1.1.1.1/tcp/1")), StandardCharsets.UTF_8);
         when(ctx.close()).thenReturn(null);
 
         var method = cls.getDeclaredMethod("messageReceived", ChannelHandlerContext.class, ByteBuf.class);

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/DiscoveryLoopSchedulingTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/DiscoveryLoopSchedulingTest.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 
 import de.flashyotter.blockchain_node.p2p.Peer;
+import de.flashyotter.blockchain_node.config.NodeProperties;
 
 class DiscoveryLoopSchedulingTest {
 
@@ -30,8 +31,9 @@ class DiscoveryLoopSchedulingTest {
         SyncService sync = mock(SyncService.class);
         kademlia = mock(KademliaService.class);
         de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p = mock(de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService.class);
+        NodeProperties props = new NodeProperties();
 
-        DiscoveryLoop target = new DiscoveryLoop(reg, sync, kademlia, libp2p);
+        DiscoveryLoop target = new DiscoveryLoop(reg, sync, kademlia, libp2p, props);
         DiscoveryLoop spySvc = spy(target);
 
         ctx = new AnnotationConfigApplicationContext();
@@ -39,6 +41,7 @@ class DiscoveryLoopSchedulingTest {
         ctx.registerBean(SyncService.class, () -> sync);
         ctx.registerBean(KademliaService.class, () -> kademlia);
         ctx.registerBean(de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService.class, () -> libp2p);
+        ctx.registerBean(NodeProperties.class, () -> props);
         ctx.registerBean(DiscoveryLoop.class, () -> spySvc);
         ctx.registerBean(ScheduledAnnotationBeanPostProcessor.class);
         ctx.refresh();


### PR DESCRIPTION
## Summary
- extend `HandshakeDto` with `publicAddr`
- store peer public addresses in `Libp2pService`
- send handshakes when peers connect
- sketch AutoNAT discovery logic
- update tests for the extended handshake

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686d280f39b883269792c2ac2185a6bb