### PR TITLE
Add write-ahead log for block storage

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStore.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/LevelDbBlockStore.java
@@ -27,7 +27,6 @@ import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
 
 /** Persistent LevelDB-based BlockStore. */
 @Component
-@Primary
 public class LevelDbBlockStore implements BlockStore, AutoCloseable {
     private final DB db;
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/WriteAheadLogBlockStore.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/WriteAheadLogBlockStore.java
@@ -1,0 +1,104 @@
+package de.flashyotter.blockchain_node.storage;
+
+import blockchain.core.model.Block;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Base64;
+
+/** BlockStore that writes all blocks to an append-only log before delegating to LevelDB. */
+@Component
+@Primary
+public class WriteAheadLogBlockStore implements BlockStore, AutoCloseable {
+    private final LevelDbBlockStore db;
+    private final Path logPath;
+    private final FileChannel logChannel;
+
+    public WriteAheadLogBlockStore(LevelDbBlockStore db, NodeProperties props) {
+        this.db = db;
+        try {
+            this.logPath = Path.of(props.getDataPath(), "block.log");
+            Files.createDirectories(logPath.getParent());
+            this.logChannel = FileChannel.open(logPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to open block log", e);
+        }
+    }
+
+    @Override
+    public void save(Block b) {
+        try {
+            String line = Base64.getEncoder().encodeToString(encode(b)) + System.lineSeparator();
+            byte[] data = line.getBytes(StandardCharsets.UTF_8);
+            ByteBuffer buf = ByteBuffer.wrap(data);
+            while (buf.hasRemaining()) logChannel.write(buf);
+            logChannel.force(true);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write block log", e);
+        }
+        db.save(b);
+    }
+
+    @Override
+    public Block findByHash(String hash) {
+        return db.findByHash(hash);
+    }
+
+    @Override
+    public Iterable<Block> loadAll() {
+        List<Block> blocks = new ArrayList<>();
+        if (!Files.exists(logPath)) return blocks;
+        try (BufferedReader br = Files.newBufferedReader(logPath)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (!line.isBlank()) {
+                    byte[] bytes = Base64.getDecoder().decode(line.trim());
+                    blocks.add(decode(bytes));
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read block log", e);
+        }
+        return blocks;
+    }
+
+    private byte[] encode(Block b) {
+        try (java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+             java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos)) {
+            oos.writeObject(b);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not serialize Block", e);
+        }
+    }
+
+    private Block decode(byte[] bytes) {
+        try (java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(bytes);
+             java.io.ObjectInputStream ois = new java.io.ObjectInputStream(bais)) {
+            return (Block) ois.readObject();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not deserialize Block", e);
+        }
+    }
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        logChannel.close();
+        db.close();
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/storage/WriteAheadLogBlockStoreTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/storage/WriteAheadLogBlockStoreTest.java
@@ -1,0 +1,78 @@
+package de.flashyotter.blockchain_node.storage;
+
+import blockchain.core.consensus.Chain;
+import blockchain.core.consensus.ConsensusParams;
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.Wallet;
+import blockchain.core.serialization.JsonUtils;
+import de.flashyotter.blockchain_node.config.JacksonConfig;
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WriteAheadLogBlockStoreTest {
+
+    @BeforeAll
+    static void initMapper() {
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        mapper.registerModule(new JacksonConfig().publicKeyModule());
+        JsonUtils.use(mapper);
+    }
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void recoverFromLogWhenDbLost() throws Exception {
+        NodeProperties props = new NodeProperties();
+        props.setDataPath(temp.toString());
+
+        WriteAheadLogBlockStore store = new WriteAheadLogBlockStore(new LevelDbBlockStore(props), props);
+        Chain c = new Chain();
+        Block g = c.getLatest();
+
+        Wallet miner = new Wallet();
+        Transaction cb = new Transaction(miner.getPublicKey(),
+                                         ConsensusParams.blockReward(1), "1");
+        Block b1 = new Block(1, g.getHashHex(), List.of(cb), g.getCompactDifficultyBits());
+        b1.mineLocally();
+        c.addBlock(b1);
+        store.save(b1);
+        store.close();
+
+        // simulate lost LevelDB
+        Path dbDir = temp.resolve("blocks");
+        if (Files.exists(dbDir)) {
+            Files.walk(dbDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try { Files.delete(p); } catch (Exception ignored) {}
+                    });
+        }
+
+        WriteAheadLogBlockStore reopened = new WriteAheadLogBlockStore(new LevelDbBlockStore(props), props);
+        List<Block> blocks = new ArrayList<>();
+        for (Block b : reopened.loadAll()) blocks.add(b);
+
+        Chain rebuilt = new Chain();
+        blocks.stream()
+              .sorted(Comparator.comparingInt(Block::getHeight))
+              .filter(bl -> bl.getHeight() > 0)
+              .forEach(rebuilt::addBlock);
+
+        assertEquals(2, rebuilt.getBlocks().size());
+        assertEquals(b1.getHashHex(), rebuilt.getLatest().getHashHex());
+        reopened.close();
+    }
+}


### PR DESCRIPTION
## Summary
- add WriteAheadLogBlockStore that logs blocks to `block.log`
- delegate LevelDB storage behind the new write-ahead layer
- load chain from the log on startup
- test crash recovery using the new log

## Testing
- `./gradlew test --no-daemon`
- `./gradlew verify --no-daemon` *(fails: Task 'verify' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6f488c0883268fda7f03cbba1f58