### PR TITLE
Add compressed snapshots with manifest

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SnapshotService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SnapshotService.java
@@ -15,11 +15,17 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /** Periodically writes the UTXO set to disk and prunes old blocks. */
 @Service
@@ -32,6 +38,8 @@ public class SnapshotService {
     private final ObjectMapper   mapper;
     private final MeterRegistry  metrics;
 
+    private static final String MANIFEST = "manifest.txt";
+
     public record Snapshot(int height,
                            Block tip,
                            Map<String, TxOutput> utxo,
@@ -42,6 +50,7 @@ public class SnapshotService {
         try {
             writeSnapshot();
             pruneBlocks();
+            compactSnapshots();
             metrics.counter(MetricsConfig.SNAPSHOT_SUCCESS).increment();
             log.info("Snapshot completed successfully");
         } catch (Exception e) {
@@ -61,16 +70,19 @@ public class SnapshotService {
                 chain.getUtxoSnapshot(),
                 chain.getCoinbaseHeightSnapshot()
         );
-        Path file = dir.resolve(String.format("%07d.json", snap.height()));
+        String name = String.format("%07d.json.gz", snap.height());
+        Path file = dir.resolve(name);
 
         IOException last = null;
         for (int attempt = 1; attempt <= 3; attempt++) {
             Path tmp = Files.createTempFile(dir, file.getFileName().toString(), ".tmp");
-            try {
-                mapper.writeValue(tmp.toFile(), snap);
+            try (OutputStream os = new GZIPOutputStream(Files.newOutputStream(tmp, StandardOpenOption.WRITE))) {
+                mapper.writeValue(os, snap);
+                os.flush();
                 Files.move(tmp, file,
                         java.nio.file.StandardCopyOption.ATOMIC_MOVE,
                         java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                updateManifest(dir, name);
                 log.info("Wrote snapshot {}", file.getFileName());
                 return;
             } catch (IOException e) {
@@ -103,25 +115,68 @@ public class SnapshotService {
         }
     }
 
+    private void updateManifest(Path dir, String name) throws IOException {
+        Path manifest = dir.resolve(MANIFEST);
+        List<String> lines = Files.exists(manifest) ? Files.readAllLines(manifest) : new ArrayList<>();
+        lines.add(name);
+        Files.write(manifest, lines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private void compactSnapshots() {
+        Path dir = Path.of(props.getDataPath(), "snapshots");
+        if (!Files.isDirectory(dir)) return;
+        try {
+            List<Path> snaps = Files.list(dir)
+                    .filter(p -> p.toString().endsWith(".json.gz"))
+                    .sorted()
+                    .toList();
+            int keep = 5;
+            if (snaps.size() <= keep) return;
+            for (int i = 0; i < snaps.size() - keep; i++) {
+                Files.deleteIfExists(snaps.get(i));
+            }
+            Path manifest = dir.resolve(MANIFEST);
+            List<String> names = snaps.subList(snaps.size() - keep, snaps.size())
+                    .stream().map(p -> p.getFileName().toString()).toList();
+            Files.write(manifest, names, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            log.warn("Snapshot compaction failed", e);
+        }
+    }
+
     /** Loads the most recent snapshot if present. */
     public Snapshot loadLatest() {
         Path dir = Path.of(props.getDataPath(), "snapshots");
         if (!Files.isDirectory(dir)) return null;
         try {
-            return Files.list(dir)
-                    .filter(p -> p.toString().endsWith(".json"))
-                    .max(Comparator.naturalOrder())
-                    .map(p -> {
-                        try {
-                            return mapper.readValue(p.toFile(), Snapshot.class);
-                        } catch (IOException e) {
-                            log.warn("Failed to read snapshot {}", p, e);
-                            return null;
-                        }
-                    }).orElse(null);
+            Path manifest = dir.resolve(MANIFEST);
+            Path latest = null;
+            if (Files.exists(manifest)) {
+                List<String> lines = Files.readAllLines(manifest);
+                if (!lines.isEmpty()) {
+                    latest = dir.resolve(lines.get(lines.size() - 1));
+                }
+            }
+            if (latest == null || !Files.exists(latest)) {
+                latest = Files.list(dir)
+                        .filter(p -> p.toString().endsWith(".json") || p.toString().endsWith(".json.gz"))
+                        .max(Comparator.naturalOrder())
+                        .orElse(null);
+            }
+            if (latest == null) return null;
+            return readSnapshot(latest);
         } catch (IOException e) {
             return null;
         }
+    }
+
+    private Snapshot readSnapshot(Path p) throws IOException {
+        if (p.toString().endsWith(".gz")) {
+            try (InputStream is = new GZIPInputStream(Files.newInputStream(p))) {
+                return mapper.readValue(is, Snapshot.class);
+            }
+        }
+        return mapper.readValue(p.toFile(), Snapshot.class);
     }
 }
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceMetricsTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceMetricsTest.java
@@ -59,7 +59,7 @@ class SnapshotServiceMetricsTest {
     void failureIncrementsCounter() throws Exception {
         ObjectMapper failingMapper = org.mockito.Mockito.mock(ObjectMapper.class);
         doThrow(new IOException()).when(failingMapper)
-                .writeValue(org.mockito.ArgumentMatchers.any(java.io.File.class), org.mockito.ArgumentMatchers.any());
+                .writeValue(org.mockito.ArgumentMatchers.any(java.io.OutputStream.class), org.mockito.ArgumentMatchers.any());
         SnapshotService failing = new SnapshotService(chain, props, mock(BlockStore.class), failingMapper, registry);
         failing.snapshotTask();
         assertEquals(1, registry.get("snapshot_failure_total").counter().count());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceRetryTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SnapshotServiceRetryTest.java
@@ -49,14 +49,16 @@ class SnapshotServiceRetryTest {
                 throw new IOException("boom");
             }
             return inv.callRealMethod();
-        }).when(mapper).writeValue(Mockito.any(File.class), Mockito.any());
+        }).when(mapper).writeValue(Mockito.any(java.io.OutputStream.class), Mockito.any());
 
         SimpleMeterRegistry metrics = new SimpleMeterRegistry();
         SnapshotService svc = new SnapshotService(chain, props, store, mapper, metrics);
         svc.snapshotTask();
 
         assertEquals(2, calls.get(), "should retry once");
-        long files = Files.list(temp.resolve("snapshots")).count();
+        long files = Files.list(temp.resolve("snapshots"))
+                          .filter(p -> p.toString().endsWith(".gz"))
+                          .count();
         assertEquals(1, files, "snapshot file created");
     }
 }


### PR DESCRIPTION
## Summary
- compress snapshot files using Gzip
- maintain snapshot manifest and compact old entries
- support loading both zipped and plain snapshots
- update tests for new OutputStream write API

## Testing
- `./gradlew check`
- `./gradlew verify` *(fails: Task 'verify' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6f1169a083268ab9720b21bf6145