### PR TITLE
Add gRPC API layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ VITE_NODE_JWT_SECRET=myTopSecret   # same secret for UI
 NODE_MINING_THREADS=4               # 0 → auto-detect
 NODE_SNAPSHOT_INTERVAL_SEC=300
 NODE_HISTORY_DEPTH=1000
+NODE_GRPC_PORT=9090
 BUILD_CA_CERT=
 
 Blocks are kept in a LevelDB database under `${NODE_DATA_PATH}/blocks`. Mount
@@ -113,6 +114,12 @@ GET  /api/chain/latest           → current tip
 GET  /api/chain/page?page=0&size=5 → paginated blocks (desc)
 
 Fully documented via Swagger / OpenAPI at runtime.
+
+### gRPC API
+
+Set `NODE_GRPC_PORT` to expose the same endpoints over gRPC (defaults to
+`9090`). Service definitions live under `blockchain-node/src/main/proto` and
+cover mining, wallet and chain queries.
 
 P2P Protocol
 

--- a/blockchain-node/build.gradle
+++ b/blockchain-node/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'org.springframework.boot'      version '3.5.1'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 group   = 'de.flashyotter'
@@ -52,6 +53,10 @@ dependencies {
     runtimeOnly    'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly    'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // gRPC server
+    implementation 'net.devh:grpc-server-spring-boot-starter:2.15.0.RELEASE'
+    compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+
     // Networking and concurrency
     implementation platform("io.netty:netty-bom:4.1.117.Final")
     implementation "io.libp2p:jvm-libp2p:1.2.2-RELEASE"
@@ -77,3 +82,18 @@ tasks.named('test') {
 tasks.named('jacocoTestReport') {
     dependsOn 'test'
 }
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.63.0"
+        }
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.plugins { grpc {} }
+        }
+    }}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/ChainGrpcService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/ChainGrpcService.java
@@ -1,0 +1,37 @@
+package de.flashyotter.blockchain_node.grpc;
+
+import de.flashyotter.blockchain_node.service.NodeService;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import de.flashyotter.blockchain_node.grpc.Empty;
+import de.flashyotter.blockchain_node.grpc.Block;
+import de.flashyotter.blockchain_node.grpc.PageRequest;
+import de.flashyotter.blockchain_node.grpc.BlockList;
+
+@GrpcService
+public class ChainGrpcService extends ChainGrpc.ChainImplBase {
+
+    private final NodeService node;
+
+    public ChainGrpcService(NodeService node) {
+        this.node = node;
+    }
+
+    @Override
+    public void latest(Empty request, StreamObserver<Block> responseObserver) {
+        var blk = node.latestBlock();
+        responseObserver.onNext(GrpcMapper.toProto(blk));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void page(PageRequest request, StreamObserver<BlockList> responseObserver) {
+        var blocks = node.blockPage(request.getPage(), request.getSize());
+        var list = BlockList.newBuilder()
+                .addAllBlocks(blocks.stream().map(GrpcMapper::toProto).toList())
+                .build();
+        responseObserver.onNext(list);
+        responseObserver.onCompleted();
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/GrpcMapper.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/GrpcMapper.java
@@ -1,0 +1,48 @@
+package de.flashyotter.blockchain_node.grpc;
+
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.TxInput;
+import blockchain.core.model.TxOutput;
+import com.google.protobuf.ByteString;
+
+/** Utility converting domain objects to their gRPC representations. */
+public final class GrpcMapper {
+    private GrpcMapper() {}
+
+    public static de.flashyotter.blockchain_node.grpc.TxInput toProto(TxInput in) {
+        return de.flashyotter.blockchain_node.grpc.TxInput.newBuilder()
+                .setReferencedOutputId(in.getReferencedOutputId())
+                .setSignature(ByteString.copyFrom(in.getSignature()))
+                .setSender(ByteString.copyFrom(in.getSender().getEncoded()))
+                .build();
+    }
+
+    public static de.flashyotter.blockchain_node.grpc.TxOutput toProto(TxOutput out) {
+        return de.flashyotter.blockchain_node.grpc.TxOutput.newBuilder()
+                .setValue(out.value())
+                .setRecipientAddress(out.recipientAddress())
+                .build();
+    }
+
+    public static de.flashyotter.blockchain_node.grpc.Transaction toProto(Transaction tx) {
+        var b = de.flashyotter.blockchain_node.grpc.Transaction.newBuilder()
+                .addAllInputs(tx.getInputs().stream().map(GrpcMapper::toProto).toList())
+                .addAllOutputs(tx.getOutputs().stream().map(GrpcMapper::toProto).toList())
+                .setMaxFee(tx.getMaxFee())
+                .setTip(tx.getTip());
+        return b.build();
+    }
+
+    public static de.flashyotter.blockchain_node.grpc.Block toProto(Block block) {
+        var b = de.flashyotter.blockchain_node.grpc.Block.newBuilder()
+                .setHeight(block.getHeight())
+                .setPreviousHashHex(block.getPreviousHashHex())
+                .setTimeMillis(block.getTimeMillis())
+                .setCompactBits(block.getCompactDifficultyBits())
+                .setNonce(block.getNonce())
+                .setMerkleRootHex(block.getMerkleRootHex())
+                .addAllTxList(block.getTxList().stream().map(GrpcMapper::toProto).toList());
+        return b.build();
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/MiningGrpcService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/MiningGrpcService.java
@@ -1,0 +1,25 @@
+package de.flashyotter.blockchain_node.grpc;
+
+import de.flashyotter.blockchain_node.service.NodeService;
+import net.devh.boot.grpc.server.service.GrpcService;
+import io.grpc.stub.StreamObserver;
+
+import de.flashyotter.blockchain_node.grpc.Empty;
+import de.flashyotter.blockchain_node.grpc.Block;
+
+@GrpcService
+public class MiningGrpcService extends MiningGrpc.MiningImplBase {
+
+    private final NodeService node;
+
+    public MiningGrpcService(NodeService node) {
+        this.node = node;
+    }
+
+    @Override
+    public void mine(Empty request, StreamObserver<Block> responseObserver) {
+        var blk = node.mineNow().block();
+        responseObserver.onNext(GrpcMapper.toProto(blk));
+        responseObserver.onCompleted();
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/WalletGrpcService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/WalletGrpcService.java
@@ -1,0 +1,47 @@
+package de.flashyotter.blockchain_node.grpc;
+
+import blockchain.core.crypto.AddressUtils;
+import de.flashyotter.blockchain_node.service.NodeService;
+import de.flashyotter.blockchain_node.wallet.WalletService;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+@GrpcService
+public class WalletGrpcService extends WalletGrpc.WalletImplBase {
+
+    private final WalletService wallet;
+    private final NodeService node;
+
+    public WalletGrpcService(WalletService wallet, NodeService node) {
+        this.wallet = wallet;
+        this.node = node;
+    }
+
+    @Override
+    public void send(SendRequest request, StreamObserver<Transaction> responseObserver) {
+        var tx = wallet.createTx(request.getRecipient(), request.getAmount(), node.currentUtxo());
+        node.submitTx(tx);
+        responseObserver.onNext(GrpcMapper.toProto(tx));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void info(Empty request, StreamObserver<WalletInfo> responseObserver) {
+        var utxo = node.currentUtxoIncludingPending();
+        double balance = wallet.balance(utxo);
+        String address = AddressUtils.publicKeyToAddress(wallet.getLocalWallet().getPublicKey());
+        var info = WalletInfo.newBuilder().setAddress(address).setBalance(balance).build();
+        responseObserver.onNext(info);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void history(HistoryRequest request, StreamObserver<TxList> responseObserver) {
+        var txs = node.walletHistory(request.getAddress(), request.getLimit());
+        var list = TxList.newBuilder()
+                .addAllTxs(txs.stream().map(GrpcMapper::toProto).toList())
+                .build();
+        responseObserver.onNext(list);
+        responseObserver.onCompleted();
+    }
+}

--- a/blockchain-node/src/main/proto/node.proto
+++ b/blockchain-node/src/main/proto/node.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+package de.flashyotter.blockchain_node.grpc;
+
+option java_multiple_files = true;
+option java_package = "de.flashyotter.blockchain_node.grpc";
+option java_outer_classname = "NodeProto";
+
+message Empty {}
+
+message TxInput {
+  string referencedOutputId = 1;
+  bytes  signature = 2;
+  bytes  sender = 3;
+}
+
+message TxOutput {
+  double value = 1;
+  string recipientAddress = 2;
+}
+
+message Transaction {
+  repeated TxInput inputs = 1;
+  repeated TxOutput outputs = 2;
+  double maxFee = 3;
+  double tip = 4;
+}
+
+message Block {
+  int32 height = 1;
+  string previousHashHex = 2;
+  int64 timeMillis = 3;
+  int32 compactBits = 4;
+  int32 nonce = 5;
+  string merkleRootHex = 6;
+  repeated Transaction txList = 7;
+}
+
+message BlockList {
+  repeated Block blocks = 1;
+}
+
+message PageRequest {
+  int32 page = 1;
+  int32 size = 2;
+}
+
+message HistoryRequest {
+  string address = 1;
+  int32 limit = 2;
+}
+
+message WalletInfo {
+  string address = 1;
+  double balance = 2;
+}
+
+message SendRequest {
+  string recipient = 1;
+  double amount = 2;
+}
+
+message TxList {
+  repeated Transaction txs = 1;
+}
+
+service Mining {
+  rpc Mine(Empty) returns (Block);
+}
+
+service Wallet {
+  rpc Send(SendRequest) returns (Transaction);
+  rpc Info(Empty) returns (WalletInfo);
+  rpc History(HistoryRequest) returns (TxList);
+}
+
+service Chain {
+  rpc Latest(Empty) returns (Block);
+  rpc Page(PageRequest) returns (BlockList);
+}

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -12,6 +12,10 @@ server:
   address: 0.0.0.0
   port: ${SERVER_PORT:3333}
 
+grpc:
+  server:
+    port: ${NODE_GRPC_PORT:9090}
+
 node:
   peers: ${NODE_PEERS:}
   data-path: data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,13 @@ services:
       MINING_THREADS:     "${MINING_THREADS}"
       NODE_SNAPSHOT_INTERVAL_SEC: "${NODE_SNAPSHOT_INTERVAL_SEC}"
       NODE_HISTORY_DEPTH: "${NODE_HISTORY_DEPTH}"
+      NODE_GRPC_PORT: "${NODE_GRPC_PORT}"
       # Keep container and host ports in sync
       SERVER_PORT:         "${BACKEND_PORT}"
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"
       - "${NODE_LIBP2P_PORT}:${NODE_LIBP2P_PORT}"
+      - "${NODE_GRPC_PORT}:${NODE_GRPC_PORT}"
     restart: unless-stopped
     secrets: [zscaler_cert]
     volumes:


### PR DESCRIPTION
## Summary
- define protobuf RPCs for mining, wallet and chain queries
- expose services via gRPC using spring-boot starter
- map domain models to proto messages
- document gRPC usage and environment variable
- expose gRPC port via docker compose

## Testing
- `./gradlew clean jacocoTestReport`

------
https://chatgpt.com/codex/tasks/task_e_686d6ef3e9cc8326932691cfbc2c2737