### PR TITLE
Use protobuf for P2P transport

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
@@ -1,0 +1,84 @@
+package de.flashyotter.blockchain_node.p2p;
+
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import de.flashyotter.blockchain_node.dto.*;
+import de.flashyotter.blockchain_node.grpc.GrpcMapper;
+import de.flashyotter.blockchain_node.p2p.P2PMessage;
+import de.flashyotter.blockchain_node.p2p.Handshake;
+import de.flashyotter.blockchain_node.p2p.NewBlock;
+import de.flashyotter.blockchain_node.p2p.NewTx;
+import de.flashyotter.blockchain_node.p2p.GetBlocks;
+import de.flashyotter.blockchain_node.p2p.Blocks;
+import de.flashyotter.blockchain_node.p2p.PeerList;
+import de.flashyotter.blockchain_node.p2p.FindNode;
+import de.flashyotter.blockchain_node.p2p.Nodes;
+
+/** Utility converting P2P DTOs to their protobuf representation and back. */
+public final class P2PProtoMapper {
+    private P2PProtoMapper() {}
+
+    public static P2PMessage toProto(P2PMessageDto dto) {
+        var builder = P2PMessage.newBuilder();
+        if (dto instanceof HandshakeDto hs) {
+            builder.setHandshake(Handshake.newBuilder()
+                    .setNodeId(hs.nodeId())
+                    .setProtocolVersion(hs.protocolVersion())
+                    .setListenPort(hs.listenPort())
+                    .setPublicAddr(hs.publicAddr() == null ? "" : hs.publicAddr())
+                    .build());
+        } else if (dto instanceof NewBlockDto nb) {
+            Block b = blockchain.core.serialization.JsonUtils.blockFromJson(nb.rawBlockJson());
+            builder.setNewBlock(NewBlock.newBuilder()
+                    .setBlock(GrpcMapper.toProto(b)).build());
+        } else if (dto instanceof NewTxDto nt) {
+            Transaction tx = blockchain.core.serialization.JsonUtils.txFromJson(nt.rawTxJson());
+            builder.setNewTx(NewTx.newBuilder()
+                    .setTx(GrpcMapper.toProto(tx)).build());
+        } else if (dto instanceof GetBlocksDto gb) {
+            builder.setGetBlocks(GetBlocks.newBuilder()
+                    .setFromHeight(gb.fromHeight()).build());
+        } else if (dto instanceof BlocksDto bd) {
+            var list = bd.rawBlocks().stream()
+                    .map(blockchain.core.serialization.JsonUtils::blockFromJson)
+                    .map(GrpcMapper::toProto).toList();
+            builder.setBlocks(Blocks.newBuilder()
+                    .addAllBlocks(list).build());
+        } else if (dto instanceof PeerListDto pl) {
+            builder.setPeerList(PeerList.newBuilder()
+                    .addAllPeers(pl.peers()).build());
+        } else if (dto instanceof FindNodeDto fn) {
+            builder.setFindNode(FindNode.newBuilder()
+                    .setNodeId(fn.nodeId()).build());
+        } else if (dto instanceof NodesDto nd) {
+            builder.setNodes(Nodes.newBuilder()
+                    .addAllNodes(nd.peers()).build());
+        }
+        return builder.build();
+    }
+
+    public static P2PMessageDto fromProto(P2PMessage msg) {
+        return switch (msg.getMsgCase()) {
+            case HANDSHAKE -> new HandshakeDto(
+                    msg.getHandshake().getNodeId(),
+                    msg.getHandshake().getProtocolVersion(),
+                    msg.getHandshake().getListenPort(),
+                    msg.getHandshake().getPublicAddr());
+            case NEWBLOCK -> new NewBlockDto(
+                    blockchain.core.serialization.JsonUtils.toJson(
+                            GrpcMapper.fromProto(msg.getNewBlock().getBlock())));
+            case NEWTX -> new NewTxDto(
+                    blockchain.core.serialization.JsonUtils.toJson(
+                            GrpcMapper.fromProto(msg.getNewTx().getTx())));
+            case GETBLOCKS -> new GetBlocksDto(msg.getGetBlocks().getFromHeight());
+            case BLOCKS -> new BlocksDto(msg.getBlocks().getBlocksList().stream()
+                    .map(GrpcMapper::fromProto)
+                    .map(blockchain.core.serialization.JsonUtils::toJson)
+                    .toList());
+            case PEERLIST -> new PeerListDto(msg.getPeerList().getPeersList());
+            case FINDNODE -> new FindNodeDto(msg.getFindNode().getNodeId());
+            case NODES -> new NodesDto(msg.getNodes().getNodesList());
+            default -> null;
+        };
+    }
+}

--- a/blockchain-node/src/main/proto/p2p.proto
+++ b/blockchain-node/src/main/proto/p2p.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+package de.flashyotter.blockchain_node.p2p;
+
+option java_multiple_files = true;
+option java_package = "de.flashyotter.blockchain_node.p2p";
+option java_outer_classname = "P2PProto";
+
+import "node.proto";
+
+message Handshake {
+  string nodeId = 1;
+  string protocolVersion = 2;
+  int32 listenPort = 3;
+  string publicAddr = 4;
+}
+
+message NewBlock {
+  de.flashyotter.blockchain_node.grpc.Block block = 1;
+}
+
+message NewTx {
+  de.flashyotter.blockchain_node.grpc.Transaction tx = 1;
+}
+
+message GetBlocks {
+  int32 fromHeight = 1;
+}
+
+message Blocks {
+  repeated de.flashyotter.blockchain_node.grpc.Block blocks = 1;
+}
+
+message PeerList {
+  repeated string peers = 1;
+}
+
+message FindNode {
+  string nodeId = 1;
+}
+
+message Nodes {
+  repeated string nodes = 1;
+}
+
+message P2PMessage {
+  oneof msg {
+    Handshake handshake = 1;
+    NewBlock newBlock = 2;
+    NewTx newTx = 3;
+    GetBlocks getBlocks = 4;
+    Blocks blocks = 5;
+    PeerList peerList = 6;
+    FindNode findNode = 7;
+    Nodes nodes = 8;
+  }
+  string jwt = 9;
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
@@ -1,9 +1,9 @@
 package de.flashyotter.blockchain_node.p2p;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.dto.HandshakeDto;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
+import de.flashyotter.blockchain_node.p2p.P2PProtoMapper;
 import de.flashyotter.blockchain_node.service.KademliaService;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.PeerRegistry;
@@ -33,15 +33,17 @@ class Libp2pHandshakeTest {
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
 
-        Libp2pService svc = new Libp2pService(host, props, new ObjectMapper(), node, kad);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());
         ctor.setAccessible(true);
         Object handler = ctor.newInstance(svc);
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        ByteBuf buf = Unpooled.copiedBuffer(new ObjectMapper()
-                .writeValueAsString(new HandshakeDto("x","0.0.1",0,"/ip4/1.1.1.1/tcp/1")), StandardCharsets.UTF_8);
+        var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
+                new HandshakeDto("x","0.0.1",0,"/ip4/1.1.1.1/tcp/1"));
+        byte[] data = msg.toByteArray();
+        ByteBuf buf = Unpooled.buffer(4 + data.length).writeInt(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
 
         var method = cls.getDeclaredMethod("messageReceived", ChannelHandlerContext.class, ByteBuf.class);
@@ -64,15 +66,17 @@ class Libp2pHandshakeTest {
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
 
-        Libp2pService svc = new Libp2pService(host, props, new ObjectMapper(), node, kad);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());
         ctor.setAccessible(true);
         Object handler = ctor.newInstance(svc);
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        ByteBuf buf = Unpooled.copiedBuffer(new ObjectMapper()
-                .writeValueAsString(new HandshakeDto("x","1.0.0",0,"/ip4/1.1.1.1/tcp/1")), StandardCharsets.UTF_8);
+        var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
+                new HandshakeDto("x","1.0.0",0,"/ip4/1.1.1.1/tcp/1"));
+        byte[] data = msg.toByteArray();
+        ByteBuf buf = Unpooled.buffer(4 + data.length).writeInt(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
 
         var method = cls.getDeclaredMethod("messageReceived", ChannelHandlerContext.class, ByteBuf.class);

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import blockchain.core.model.Transaction;
 import blockchain.core.model.TxOutput;
 import blockchain.core.serialization.JsonUtils;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.dto.NewTxDto;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
@@ -91,8 +90,8 @@ class Libp2pServiceBroadcastTest {
         KademliaService k1 = new KademliaService(t1, r1, props1);
         KademliaService k2 = new KademliaService(t2, r2, props2);
 
-        s1 = new Libp2pService(h1, props1, new ObjectMapper(), n1, k1);
-        s2 = new Libp2pService(h2, props2, new ObjectMapper(), n2, k2);
+        s1 = new Libp2pService(h1, props1, n1, k1);
+        s2 = new Libp2pService(h2, props2, n2, k2);
         s1.init();
         s2.init();
     }


### PR DESCRIPTION
## Summary
- switch Libp2p messages from JSON to protobuf and add length prefix
- add optional JWT signing/verification for P2P frames
- extend rate limiter to track buckets per peer
- provide mapper for converting DTOs to protobuf
- update affected tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686d76f28ea08326b754803bc34d600f