### PR TITLE
Improve docs for compose and gRPC

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -3,3 +3,4 @@ GitHub Actions workflows live in this directory.
 - `workflows/ci.yml` sets up JDK 17, caches Gradle and runs
   `./gradlew clean jacocoTestReport`. Successful builds upload the node and
   core JARs as artifacts.
+- End-to-end tests exercise the gRPC API against a multi-node setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Directories and notable files
 - `data/` – runtime LevelDB store for blocks and wallet.
 - `settings.gradle` – lists included modules.
 - `README.md` – build and usage instructions.
+- gRPC API available on `NODE_GRPC_PORT` (default 9090).
+- Gradle tasks `composeUp` / `composeDown` manage the Docker Compose setup.
 
 Overall relationship
 --------------------

--- a/README.md.agent.md
+++ b/README.md.agent.md
@@ -1,1 +1,0 @@
-This README describes how to build and run the demo blockchain node. It documents available REST and gRPC endpoints, protobuf‑based P2P messages and hints for running a private network. Use it as a primer when exploring the project.

--- a/blockchain-core/AGENTS.md
+++ b/blockchain-core/AGENTS.md
@@ -10,5 +10,7 @@ Packages under `src/main/java/blockchain/core`:
 - `serialization` – JSON helpers (`JsonUtils`).
 - `exceptions` – custom runtime `BlockchainException`.
 
+Proto definitions in `blockchain-node/src/main/proto` map these models for gRPC.
+
 Tests in `src/test/java` mirror these packages. Build logic resides in
 `build.gradle`.

--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -9,6 +9,7 @@ Important paths under `src/main/java/de/flashyotter/blockchain_node`:
 - `p2p/` – `Peer`, `PeerClient` and `PeerServer` for libp2p networking.
 - `storage/` – `BlockStore` with LevelDB and in-memory implementations.
 - `wallet/` – wallet and keystore utilities.
+- `grpc/` – service implementations from `src/main/proto`.
 
 Resources in `src/main/resources` define application defaults. Tests in
 `src/test` cover controllers, services and networking.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
@@ -6,6 +6,7 @@ This package contains the services composing the node.
 - `P2PBroadcastService` (via `P2PBroadcastPort`) – sends blocks and txs to peers.
 - `PeerService` with `PeerRegistry` – manages the list of known peers.
 - `DiscoveryLoop` and `SyncService` – keep peers connected and the chain synced.
+- gRPC service classes expose these operations remotely.
 
 ```plantuml
 @startuml

--- a/gradle/AGENTS.md
+++ b/gradle/AGENTS.md
@@ -2,3 +2,4 @@ Gradle wrapper files and the shared version catalog.
 
 - `wrapper/` – `gradle-wrapper.jar` and properties used to bootstrap Gradle.
 - `libs.versions.toml` – central place for dependency versions.
+- Compose plugin provides `composeUp` and `composeDown` tasks.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -7,5 +7,6 @@ Key files:
 - `vite.config.ts` – Vite build configuration.
 - `src/` – TypeScript sources and tests.
 - `tsconfig*.json` – TypeScript compiler settings.
+- Communicates with the backend via REST and gRPC clients.
 
 Run `npm install` then `npm run dev` in this directory to start the dev server.

--- a/ui/src/AGENTS.md
+++ b/ui/src/AGENTS.md
@@ -8,4 +8,6 @@ Folders:
 - `assets/` – static assets such as `react.svg`.
 - `__tests__/` – unit tests for components and pages.
 
+- `services/` – generated gRPC client bindings.
+
 Entry point `main.tsx` bootstraps React.


### PR DESCRIPTION
## Summary
- rewrite README intro and fix compose commands
- document gRPC API usage
- mention compose tasks and gRPC support in all AGENTS
- remove obsolete README agent

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68702657d01483268e416a7c8a588d36