### PR TITLE
Fix pipeline e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Run end-to-end tests
       run: |
-        pip install selenium requests PyJWT behave grpcio
+        pip install selenium requests PyJWT behave grpcio protobuf
         behave pipeline-tests/e2e.feature
 
     - name: Stop containers


### PR DESCRIPTION
## Summary
- install protobuf in CI workflow so `node_pb2` imports work

## Testing
- `./gradlew test --no-daemon`
- `behave pipeline-tests/e2e.feature` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68708a0029788326ae1a5fe4c057a94d