### PR TITLE
Expose gRPC address

### DIFF
--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -14,6 +14,7 @@ server:
 
 grpc:
   server:
+    address: 0.0.0.0
     port: ${NODE_GRPC_PORT:9090}
 
 node:


### PR DESCRIPTION
## Summary
- expose the gRPC server on 0.0.0.0 so CI tests can reach it

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68717468d9248326859283a260f92291