### PR TITLE
Drop static publicAddr from handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ A lean Java&nbsp;21 and Spring Boot&nbsp;3 blockchain node demonstrating a moder
 - Write-ahead log for replay-safe LevelDB storage
 - Compressed UTXO snapshots tracked via manifest
 - Structured JSON logging with Prometheus metrics
-- Handshake advertises the node's public address for autodiscovery
 - P2P messages encoded with protobuf
 
 ## Feature matrix
@@ -111,7 +110,7 @@ Set `NODE_GRPC_PORT` to expose the same endpoints over gRPC (defaults to `9090`)
 
 ## P2P protocol
 
-The node announces itself on `/simple-blockchain/*`. Handshake messages include the node's public address for discovery. All data is encoded using the protobuf definitions in `p2p.proto`.
+The node announces itself on `/simple-blockchain/*`. All handshake data is encoded using the protobuf definitions in `p2p.proto`.
 
 - Control – peer list, find-node, range sync
 - Blocks  – single block messages

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
@@ -11,10 +11,8 @@ package de.flashyotter.blockchain_node.dto;
  * @param nodeId          arbitrary, human-friendly identifier
  * @param protocolVersion semantic protocol version (major.minor.patch)
  * @param listenPort      TCP port the node is accepting peer connections on
- * @param publicAddr      multiaddress observed via AutoNAT
  */
 public record HandshakeDto(String nodeId,
                            String protocolVersion,
-                           int listenPort,
-                           String publicAddr)
+                           int listenPort)
         implements P2PMessageDto { }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
@@ -25,7 +25,6 @@ public final class P2PProtoMapper {
                     .setNodeId(hs.nodeId())
                     .setProtocolVersion(hs.protocolVersion())
                     .setListenPort(hs.listenPort())
-                    .setPublicAddr(hs.publicAddr() == null ? "" : hs.publicAddr())
                     .build());
         } else if (dto instanceof NewBlockDto nb) {
             Block b = blockchain.core.serialization.JsonUtils.blockFromJson(nb.rawBlockJson());
@@ -62,8 +61,7 @@ public final class P2PProtoMapper {
             case HANDSHAKE -> new HandshakeDto(
                     msg.getHandshake().getNodeId(),
                     msg.getHandshake().getProtocolVersion(),
-                    msg.getHandshake().getListenPort(),
-                    msg.getHandshake().getPublicAddr());
+                    msg.getHandshake().getListenPort());
             case NEWBLOCK -> new NewBlockDto(
                     blockchain.core.serialization.JsonUtils.toJson(
                             GrpcMapper.fromProto(msg.getNewBlock().getBlock())));

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -27,8 +27,7 @@ public class DiscoveryLoop {
             libp2p.send(p, new de.flashyotter.blockchain_node.dto.HandshakeDto(
                     kademlia.selfId(),
                     libp2p.protocolVersion(),
-                    props.getLibp2pPort(),
-                    libp2p.getPublicAddr()));
+                    props.getLibp2pPort()));
         }
     }
 }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -38,8 +38,7 @@ public class PeerService {
                     libp2p.send(p, new de.flashyotter.blockchain_node.dto.HandshakeDto(
                             props.getId(),
                             libp2p.protocolVersion(),
-                            props.getLibp2pPort(),
-                            libp2p.getPublicAddr()));
+                            props.getLibp2pPort()));
                 });
 
         broadcaster.broadcastPeerList();

--- a/blockchain-node/src/main/proto/p2p.proto
+++ b/blockchain-node/src/main/proto/p2p.proto
@@ -11,7 +11,6 @@ message Handshake {
   string nodeId = 1;
   string protocolVersion = 2;
   int32 listenPort = 3;
-  string publicAddr = 4;
 }
 
 message NewBlock {

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class Libp2pHandshakeTest {
@@ -41,7 +42,7 @@ class Libp2pHandshakeTest {
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
-                new HandshakeDto("x","0.0.1",0,"/ip4/1.1.1.1/tcp/1"));
+                new HandshakeDto("x","0.0.1",0));
         byte[] data = msg.toByteArray();
         ByteBuf buf = Unpooled.buffer(4 + data.length).writeInt(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
@@ -73,8 +74,13 @@ class Libp2pHandshakeTest {
         Object handler = ctor.newInstance(svc);
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        io.netty.channel.Channel ch = mock(io.netty.channel.Channel.class);
+        when(ctx.channel()).thenReturn(ch);
+        java.net.InetSocketAddress addr = new java.net.InetSocketAddress("1.2.3.4", 10000);
+        when(ch.remoteAddress()).thenReturn(addr);
+
         var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
-                new HandshakeDto("x","1.0.0",0,"/ip4/1.1.1.1/tcp/1"));
+                new HandshakeDto("x","1.0.0",7000));
         byte[] data = msg.toByteArray();
         ByteBuf buf = Unpooled.buffer(4 + data.length).writeInt(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
@@ -84,5 +90,6 @@ class Libp2pHandshakeTest {
         method.invoke(handler, ctx, buf);
 
         verify(ctx, never()).close();
+        assertTrue(reg.all().contains(new Peer("1.2.3.4", 7000)));
     }
 }


### PR DESCRIPTION
## Summary
- remove `publicAddr` from `HandshakeDto` and protocol definition
- update mapper and services to use new handshake format
- record inbound peers when receiving handshake
- adjust tests and documentation

## Testing
- `./gradlew test`
- `behave pipeline-tests/e2e.feature` *(fails: gRPC service on port 9090 not ready)*

------
https://chatgpt.com/codex/tasks/task_e_687295e765688326a9de9e4bdb569cf2