### PR TITLE
Fix circular dependency preventing node startup

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Libp2pConfig.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Libp2pConfig.java
@@ -8,6 +8,7 @@ import io.libp2p.crypto.keys.Secp256k1Kt;
 import io.libp2p.core.mux.StreamMuxerProtocol;
 import io.libp2p.discovery.MDnsDiscovery;
 import io.libp2p.protocol.autonat.AutonatProtocol;
+import io.libp2p.protocol.autonat.AutonatProtocol.Binding;
 import org.apache.tuweni.kademlia.KademliaRoutingTable;
 import java.nio.charset.StandardCharsets;
 import de.flashyotter.blockchain_node.p2p.Peer;
@@ -35,7 +36,7 @@ public class Libp2pConfig {
                 .transport(TcpTransport::new)
                 .secureChannel(secureFactory)
                 .muxer(StreamMuxerProtocol::getYamux)
-                .protocol((io.libp2p.core.multistream.ProtocolBinding<?>) new AutonatProtocol())
+                .protocol(new Binding())
                 .listen(addr.toString())
                 .build();
         host.start().join();

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -36,6 +36,7 @@ public class Libp2pService {
 
     private final Host           host;
     private final NodeProperties props;
+    @org.springframework.context.annotation.Lazy
     private final NodeService    node;
     private final KademliaService kademlia;
 


### PR DESCRIPTION
## Summary
- mark `NodeService` injection in `Libp2pService` as `@Lazy` to avoid a circular dependency

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`
- `behave pipeline-tests/e2e.feature` *(fails: gRPC service on port 9090 not ready)*

------
https://chatgpt.com/codex/tasks/task_e_6872bee447148326979b0cc5de26678d