### PR TITLE
Fix e2e pipeline startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,7 @@ jobs:
       run: docker run -d --name selenium -p 4444:4444 selenium/standalone-chrome
 
     - name: Build & start multi-node setup
-      run: docker compose -f docker-compose.ci.yml up -d --build
-
-    - name: Wait for nodes
-      run: sleep 30
+      run: docker compose -f docker-compose.ci.yml up -d --build --wait
 
     - name: Run end-to-end tests
       run: |

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -24,6 +24,11 @@ services:
     volumes:
       - ./data1:/app/data1
       - ./wallet1:/root/.simple-chain
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/$NODE_GRPC_PORT'"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
   frontend1:
     build:
       context: ./ui
@@ -61,6 +66,11 @@ services:
     volumes:
       - ./data2:/app/data2
       - ./wallet2:/root/.simple-chain
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/$NODE_GRPC_PORT'"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
   frontend2:
     build:
       context: ./ui


### PR DESCRIPTION
## Summary
- wait for containers to become healthy before running tests
- add health checks for the blockchain nodes

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6872d10c17c48326983bec828f5315c7