### PR TITLE
Fix bean cycle by injecting NodeService lazily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,23 @@ jobs:
       run: docker run -d --name selenium -p 4444:4444 selenium/standalone-chrome
 
     - name: Build & start multi-node setup
+      id: compose
       run: docker compose -f docker-compose.ci.yml up -d --build --wait
+
+    - name: Dump logs if compose failed
+      if: failure() && steps.compose.outcome == 'failure'
+      run: |
+        docker compose -f docker-compose.ci.yml ps
+        docker compose -f docker-compose.ci.yml logs --no-color
 
     - name: Run end-to-end tests
       run: |
         pip install selenium requests PyJWT behave grpcio protobuf
         behave pipeline-tests/e2e.feature
+
+    - name: Dump logs on test failure
+      if: failure()
+      run: docker compose -f docker-compose.ci.yml logs --no-color
 
     - name: Stop containers
       if: always()

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -18,12 +18,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import java.nio.ByteBuffer;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class Libp2pService {
 
@@ -34,11 +32,19 @@ public class Libp2pService {
 
     private final PeerRateLimiter rateLimiter = new PeerRateLimiter(50, 50);
 
-    private final Host           host;
+    private final Host host;
     private final NodeProperties props;
-    @org.springframework.context.annotation.Lazy
-    private final NodeService    node;
+    private final NodeService node;
     private final KademliaService kademlia;
+
+    public Libp2pService(Host host, NodeProperties props,
+                         @org.springframework.context.annotation.Lazy NodeService node,
+                         KademliaService kademlia) {
+        this.host = host;
+        this.props = props;
+        this.node = node;
+        this.kademlia = kademlia;
+    }
 
     private volatile String publicAddr;
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,6 +13,7 @@ services:
       NODE_JWT_SECRET: changeMeSuperSecret
       NODE_WALLET_PASSWORD: changeMeSuperSecret
       NODE_GRPC_PORT: 9090
+      NODE_DATA_PATH: data1
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
@@ -57,6 +58,9 @@ services:
       NODE_JWT_SECRET: changeMeSuperSecret
       NODE_WALLET_PASSWORD: changeMeSuperSecret
       NODE_GRPC_PORT: 9091
+      NODE_DATA_PATH: data2
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "3334:3334"
       - "4002:4002"


### PR DESCRIPTION
## Summary
- break Libp2pService -> NodeService circular dependency
- improve CI logging when container startup or tests fail

## Testing
- `./gradlew clean jacocoTestReport --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687331a20e40832693e53cc5427d742a