### PR TITLE
Fix compose healthcheck variable

### DIFF
--- a/blockchain-node/Dockerfile
+++ b/blockchain-node/Dockerfile
@@ -35,6 +35,7 @@ RUN gradle :blockchain-node:bootJar --no-daemon
 # 2) Runtime Stage: slim JRE with the built JAR
 # ------------------------------------------------
 FROM eclipse-temurin:21-jre
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 # Build-time port is passed from docker-compose
 ARG SERVER_PORT=3333

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
@@ -24,7 +24,8 @@ public class Peer {
 
     /** Multiaddr for libp2p connections. */
     public String multiAddr() {
-        String base = "/ip4/" + host + "/tcp/" + port;
+        String prefix = host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") ? "/ip4/" : "/dns4/";
+        String base = prefix + host + "/tcp/" + port;
         return id == null ? base : base + "/p2p/" + id;
     }
 

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
@@ -14,6 +14,18 @@ class PeerTest {
     }
 
     @Test
+    void multiAddrUsesDnsForHostnames() {
+        Peer p = new Peer("example.com", 4001);
+        assertEquals("/dns4/example.com/tcp/4001", p.multiAddr());
+    }
+
+    @Test
+    void multiAddrUsesIp4ForNumericHosts() {
+        Peer p = new Peer("1.2.3.4", 4001);
+        assertEquals("/ip4/1.2.3.4/tcp/4001", p.multiAddr());
+    }
+
+    @Test
     void fromStringParsesValid() {
         Peer p = Peer.fromString("host:1234");
         assertEquals("host", p.getHost());

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -26,7 +26,7 @@ services:
       - ./data1:/app/data1
       - ./wallet1:/root/.simple-chain
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/$NODE_GRPC_PORT'"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:$$SERVER_PORT/actuator/health >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 24
@@ -71,7 +71,7 @@ services:
       - ./data2:/app/data2
       - ./wallet2:/root/.simple-chain
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/$NODE_GRPC_PORT'"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:$$SERVER_PORT/actuator/health >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 24


### PR DESCRIPTION
## Summary
- ensure docker-compose passes SERVER_PORT env var to container healthchecks
- update multiaddr builder to choose dns4 or ip4 prefix appropriately
- add tests for Peer multiaddr behavior
- install curl in backend Dockerfile for healthcheck

## Testing
- `./gradlew test --no-daemon`
- `docker-compose -f docker-compose.ci.yml config`

------
https://chatgpt.com/codex/tasks/task_e_68734fbe3e288326a5aeb0ca794ae8b1