### PR TITLE
Add node id public REST endpoint

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/NodeController.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/NodeController.java
@@ -1,0 +1,19 @@
+package de.flashyotter.blockchain_node.controller;
+
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import de.flashyotter.blockchain_node.dto.NodeIdDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Public endpoint exposing this node's identifier. */
+@RestController
+@RequiredArgsConstructor
+public class NodeController {
+    private final NodeProperties props;
+
+    @GetMapping("/node/id")
+    public NodeIdDto id() {
+        return new NodeIdDto(props.getId());
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/NodeIdDto.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/NodeIdDto.java
@@ -1,0 +1,4 @@
+package de.flashyotter.blockchain_node.dto;
+
+/** Simple DTO returning the node identifier. */
+public record NodeIdDto(String nodeId) {}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -3,6 +3,8 @@ package de.flashyotter.blockchain_node.service;
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.p2p.Peer;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
+import de.flashyotter.blockchain_node.dto.NodeIdDto;
+import org.springframework.web.reactive.function.client.WebClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import jakarta.annotation.PostConstruct;          // ← switched to Jakarta namespace
@@ -20,14 +22,28 @@ public class PeerService {
     private final P2PBroadcastService  broadcaster;
     private final KademliaService      kademlia;
     private final de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p;
+    private final WebClient            webClient;
 
     @PostConstruct
     public void init() {
         props.getPeers().forEach(addr -> {
             var sp = addr.split(":");
-            Peer p = new Peer(sp[0], Integer.parseInt(sp[1]));
-            registry.add(p);
-            kademlia.store(p);
+            String host = sp[0];
+            int port = Integer.parseInt(sp[1]);
+            try {
+                NodeIdDto dto = webClient.get()
+                        .uri("http://" + host + ':' + port + "/node/id")
+                        .retrieve()
+                        .bodyToMono(NodeIdDto.class)
+                        .block(java.time.Duration.ofSeconds(3));
+                Peer p = new Peer(host, port, dto != null ? dto.nodeId() : null);
+                registry.add(p);
+                kademlia.store(p);
+            } catch (Exception e) {
+                Peer p = new Peer(host, port);
+                registry.add(p);
+                kademlia.store(p);
+            }
         });
 
         registry.all()

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/NodeControllerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/controller/NodeControllerTest.java
@@ -1,0 +1,30 @@
+package de.flashyotter.blockchain_node.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.flashyotter.blockchain_node.config.NodeProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(NodeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NodeControllerTest {
+
+    @Autowired MockMvc mvc;
+    @MockBean NodeProperties props;
+
+    @Test
+    void exposesId() throws Exception {
+        when(props.getId()).thenReturn("node-123");
+        mvc.perform(get("/node/id"))
+           .andExpect(status().isOk())
+           .andExpect(content().json("{\"nodeId\":\"node-123\"}"));
+    }
+}

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.mockito.Mockito;
 
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.p2p.Peer;
@@ -19,9 +20,9 @@ import de.flashyotter.blockchain_node.service.PeerService;
 import de.flashyotter.blockchain_node.service.SyncService;
 import de.flashyotter.blockchain_node.service.KademliaService;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
+import org.springframework.web.reactive.function.client.WebClient;
 import de.flashyotter.blockchain_node.dto.FindNodeDto;
-import de.flashyotter.blockchain_node.service.KademliaService;
-import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
+import de.flashyotter.blockchain_node.dto.NodeIdDto;
 import reactor.core.publisher.Flux;
 
 class PeerServiceTest {
@@ -41,6 +42,8 @@ class PeerServiceTest {
     @Mock
     private Libp2pService libp2p;
 
+    private WebClient webClient;
+
 
     private PeerService svc;
     private NodeProperties props;
@@ -51,7 +54,14 @@ class PeerServiceTest {
         props = new NodeProperties();
         // set two peers
         props.setPeers(java.util.List.of("one:100", "two:200"));
-        svc = new PeerService(props, sync, reg, broad, kademlia, libp2p);
+        webClient = Mockito.mock(WebClient.class, Mockito.RETURNS_DEEP_STUBS);
+        when(webClient.get()
+                .uri(Mockito.anyString())
+                .retrieve()
+                .bodyToMono(Mockito.eq(NodeIdDto.class)))
+            .thenReturn(reactor.core.publisher.Mono.just(new NodeIdDto("id")));
+
+        svc = new PeerService(props, sync, reg, broad, kademlia, libp2p, webClient);
     }
 
     @Test
@@ -62,14 +72,14 @@ class PeerServiceTest {
         svc.init();
 
         // registry.add for each peer string
-        verify(reg).add(new Peer("one", 100));
-        verify(reg).add(new Peer("two", 200));
-        verify(kademlia).store(new Peer("one", 100));
-        verify(kademlia).store(new Peer("two", 200));
+        verify(reg).add(new Peer("one", 100, "id"));
+        verify(reg).add(new Peer("two", 200, "id"));
+        verify(kademlia).store(new Peer("one", 100, "id"));
+        verify(kademlia).store(new Peer("two", 200, "id"));
 
         // followPeer called for each peer
-        verify(sync).followPeer(new Peer("one", 100));
-        verify(sync).followPeer(new Peer("two", 200));
+        verify(sync).followPeer(new Peer("one", 100, "id"));
+        verify(sync).followPeer(new Peer("two", 200, "id"));
         verify(libp2p, times(2)).send(any(Peer.class), any(FindNodeDto.class));
 
         // broadcastPeerList at end


### PR DESCRIPTION
## Summary
- expose node ID with new `/node/id` endpoint
- fetch peer IDs during startup in `PeerService`
- cover new endpoint and service logic in tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6873d2b964348326b1f8e02672cc3ad0