### PR TITLE
Fix node sync when broadcast missed

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -30,5 +30,17 @@ public class DiscoveryLoop {
                     props.getLibp2pPort()));
         }
     }
+
+    /**
+     * Periodically poll all known peers for new blocks. This acts as a safety
+     * net in case the initial sync happens before peers start mining or a
+     * broadcast gets lost.
+     */
+    @Scheduled(fixedDelay = 5000)
+    void refreshKnownPeers() {
+        for (Peer p : reg.all()) {
+            sync.followPeer(p).subscribe();
+        }
+    }
 }
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -26,15 +26,17 @@ public class PeerService {
 
     @PostConstruct
     public void init() {
+        int offset = props.getLibp2pPort() - props.getPort();
         props.getPeers().forEach(addr -> {
             var sp = addr.split(":");
             String host = sp[0];
             int port = Integer.parseInt(sp[1]);
             PeerIdDto dto = null;
+            int httpPort = port - offset;
             for (int i = 0; i < 10 && dto == null; i++) {
                 try {
                     dto = webClient.get()
-                            .uri("http://" + host + ':' + port + "/node/peer-id")
+                            .uri("http://" + host + ':' + httpPort + "/node/peer-id")
                             .retrieve()
                             .bodyToMono(PeerIdDto.class)
                             .block(java.time.Duration.ofSeconds(3));


### PR DESCRIPTION
## Summary
- ensure discovery loop regularly re-syncs known peers
- fetch peer ID using HTTP port derived from libp2p offset

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687403b4f6ec83268554abbc15bc3078