### PR TITLE
Fix pipeline issues

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -152,6 +152,11 @@ public class Libp2pService {
                             try {
                                 if (msg.readableBytes() < 4) return;
                                 int len = msg.readInt();
+                                if (len > 1_000_000) {
+                                    log.warn("libp2p inbound failed: length {} exceeds limit", len);
+                                    ctx.close();
+                                    return;
+                                }
                                 byte[] data = new byte[len];
                                 msg.readBytes(data);
                                 P2PMessage pm = P2PMessage.parseFrom(data);
@@ -197,6 +202,11 @@ public class Libp2pService {
             try {
                 if (msg.readableBytes() < 4) return;
                 int len = msg.readInt();
+                if (len > 1_000_000) {
+                    log.warn("libp2p inbound failed: length {} exceeds limit", len);
+                    ctx.close();
+                    return;
+                }
                 byte[] data = new byte[len];
                 msg.readBytes(data);
                 P2PMessage pm = P2PMessage.parseFrom(data);
@@ -337,6 +347,11 @@ public class Libp2pService {
             try {
                 if (msg.readableBytes() < 4) return;
                 int len = msg.readInt();
+                if (len > 1_000_000) {
+                    log.warn("libp2p inbound failed: length {} exceeds limit", len);
+                    ctx.close();
+                    return;
+                }
                 byte[] data = new byte[len];
                 msg.readBytes(data);
                 P2PMessage pm = P2PMessage.parseFrom(data);

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -33,7 +33,8 @@ public class PeerService {
             int port = Integer.parseInt(sp[1]);
             PeerIdDto dto = null;
             int httpPort = port - offset;
-            for (int i = 0; i < 10 && dto == null; i++) {
+            // nodes may take a while to start in CI
+            for (int i = 0; i < 30 && dto == null; i++) {
                 try {
                     dto = webClient.get()
                             .uri("http://" + host + ':' + httpPort + "/node/peer-id")

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   backend1:


### PR DESCRIPTION
## Summary
- set compose version to null to remove deprecation warning
- limit inbound libp2p message size so invalid frames close the connection

## Testing
- `./gradlew test --no-daemon`
- `behave pipeline-tests/e2e.feature` *(fails: gRPC service not ready)*

------
https://chatgpt.com/codex/tasks/task_e_6874129cd2108326993b7de59b7e5e79