### PR TITLE
Fix peer id resolution

### DIFF
--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pAutoNatTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pAutoNatTest.java
@@ -10,6 +10,7 @@ import io.libp2p.core.PeerId;
 import io.libp2p.core.multiformats.Multiaddr;
 import org.apache.tuweni.kademlia.KademliaRoutingTable;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -33,8 +34,9 @@ class Libp2pAutoNatTest {
                 p -> p.toString().getBytes(StandardCharsets.UTF_8), p -> 0);
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
+        WebClient client = WebClient.builder().build();
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad);
+        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
         svc.discoverPublicAddr(new Peer("dummy", 1));
 
         assertEquals(addr.toString(), svc.getPublicAddr());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pKademliaHandlerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pKademliaHandlerTest.java
@@ -15,6 +15,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.tuweni.kademlia.KademliaRoutingTable;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -38,8 +39,9 @@ class Libp2pKademliaHandlerTest {
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
         kad.store(new Peer("x", 1));
+        WebClient client = WebClient.builder().build();
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad);
+        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
         // instantiate handler via reflection
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
@@ -89,9 +90,10 @@ class Libp2pServiceBroadcastTest {
                 p -> p.toString().getBytes(StandardCharsets.UTF_8), p -> 0);
         KademliaService k1 = new KademliaService(t1, r1, props1);
         KademliaService k2 = new KademliaService(t2, r2, props2);
+        WebClient client = WebClient.builder().build();
 
-        s1 = new Libp2pService(h1, props1, n1, k1);
-        s2 = new Libp2pService(h2, props2, n2, k2);
+        s1 = new Libp2pService(h1, props1, n1, k1, client);
+        s2 = new Libp2pService(h2, props2, n2, k2, client);
         s1.init();
         s2.init();
     }


### PR DESCRIPTION
## Summary
- resolve peer id when accepting libp2p handshakes
- inject WebClient into `Libp2pService`
- adapt unit tests for new constructor

## Testing
- `./gradlew test`
- `behave pipeline-tests/e2e.feature` *(fails: gRPC service on port 9090 not ready)*

------
https://chatgpt.com/codex/tasks/task_e_6878a2c64ae0832683b2f9ed8097abd7