### PR TITLE
Add runtime image step for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       working-directory: ui
       run: npm run test -- --run
 
+    - name: Build runtime image
+      run: docker build -t simple-blockchain-node:runtime -f Dockerfile.backend .
+
     - name: Start Selenium container
       run: docker run -d --name selenium -p 4444:4444 selenium/standalone-chrome
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Pipeline Green Story: added local CI script and improved sync waiting in E2E tests.
+- Docker Compose uses prebuilt `simple-blockchain-node:runtime` image for faster startup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to Simple Blockchain
+
+Thank you for your interest in improving this project!
+
+## Local CI
+
+Run the same checks as GitHub Actions locally with:
+
+```bash
+./scripts/ci-local.sh
+```
+
+The script runs unit tests, builds a reusable runtime image and executes the
+end-to-end scenario defined in `pipeline-tests/e2e.feature`.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,11 +1,7 @@
 
 services:
   backend1:
-    build:
-      context: .
-      dockerfile: blockchain-node/Dockerfile
-      args:
-        SERVER_PORT: 3333
+    image: simple-blockchain-node:runtime
     environment:
       SERVER_PORT: 3333
       NODE_LIBP2P_PORT: 4001
@@ -43,11 +39,7 @@ services:
         condition: service_healthy
 
   backend2:
-    build:
-      context: .
-      dockerfile: blockchain-node/Dockerfile
-      args:
-        SERVER_PORT: 3334
+    image: simple-blockchain-node:runtime
     environment:
       SERVER_PORT: 3334
       NODE_LIBP2P_PORT: 4002

--- a/pipeline-tests/steps/e2e_steps.py
+++ b/pipeline-tests/steps/e2e_steps.py
@@ -53,7 +53,8 @@ def step_check_sync(context):
     wait_for_grpc(GRPC_PORT2)
     with grpc.insecure_channel(f"localhost:{GRPC_PORT2}") as channel:
         stub = ChainStub(channel)
-        for _ in range(10):
+        deadline = time.time() + 20
+        while time.time() < deadline:
             latest = stub.Latest(Empty())
             if latest.height >= target:
                 context.latest = {
@@ -62,8 +63,8 @@ def step_check_sync(context):
                     "hashHex": ""  # not needed in test
                 }
                 return
-            time.sleep(3)
-    raise AssertionError("Node2 did not sync the mined block")
+            time.sleep(1)
+    raise AssertionError("Node2 did not sync the mined block in time")
 
 @then("node1 should have a positive balance")
 def step_check_balance(context):

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Local CI simulation for Simple Blockchain
+
+# Run backend unit tests and build jar
+./gradlew clean bootJar jacocoTestReport --no-daemon
+
+# Install UI dependencies and run tests
+pushd ui > /dev/null
+npm ci
+npm run test -- --run
+popd > /dev/null
+
+# Build runtime image and start multi-node setup
+docker build -t simple-blockchain-node:runtime -f Dockerfile.backend .
+COMPOSE_FILE=docker-compose.ci.yml
+docker compose -f $COMPOSE_FILE up -d --build
+
+# Wait for containers to become healthy
+for i in {1..30}; do
+  if docker compose -f $COMPOSE_FILE ps | grep -q "healthy"; then
+    break
+  fi
+  sleep 5
+done
+
+# Run end-to-end tests
+pip install selenium requests PyJWT behave grpcio protobuf
+behave pipeline-tests/e2e.feature
+STATUS=$?
+
+docker compose -f $COMPOSE_FILE down
+exit $STATUS


### PR DESCRIPTION
## Summary
- optimize docker-compose.ci.yml to use the `simple-blockchain-node:runtime` image
- build the runtime image in CI and local helper script
- document updated workflow in CONTRIBUTING and CHANGELOG

## Testing
- `./gradlew test`
- `npm test -- --run`
- `behave pipeline-tests/e2e.feature` *(fails: gRPC service not ready)*

------
https://chatgpt.com/codex/tasks/task_e_6878dfcc491c8326b0161da9eaf23d63