### PR TITLE
Fix libp2p frame parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: ci-local
+ci-local:
+	./scripts/ci-local.sh

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ inside Docker Compose succeed.
 
 Fork the repo, create a branch, run `./gradlew verify` and open a PR.
 
+## Run CI locally
+
+Execute the same checks that GitHub Actions runs with:
+
+```bash
+make ci-local
+```
+
+This convenience target invokes `scripts/ci-local.sh` which runs unit tests,
+builds the Docker images and executes the end-to-end scenario defined in
+`pipeline-tests/e2e.feature`.
+
+Set the environment variable `FLAKY_RETRY=1` to allow the mining step in the
+Behave tests to retry up to three times if a transient failure occurs.
+
 ## Roadmap
 
 The planned improvements for upcoming releases are outlined in

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -155,7 +155,12 @@ public class Libp2pService {
                         public void messageReceived(ChannelHandlerContext ctx, ByteBuf msg) {
                             try {
                                 if (msg.readableBytes() < 4) return;
+                                msg.markReaderIndex();
                                 int len = msg.readIntLE();
+                                if (msg.readableBytes() < len) {
+                                    msg.resetReaderIndex();
+                                    return;
+                                }
                                 if (len > 1_000_000) {
                                     log.warn("libp2p inbound failed: length {} exceeds limit", len);
                                     ctx.close();
@@ -205,7 +210,12 @@ public class Libp2pService {
             }
             try {
                 if (msg.readableBytes() < 4) return;
+                msg.markReaderIndex();
                 int len = msg.readIntLE();
+                if (msg.readableBytes() < len) {
+                    msg.resetReaderIndex();
+                    return;
+                }
                 if (len > 1_000_000) {
                     log.warn("libp2p inbound failed: length {} exceeds limit", len);
                     ctx.close();
@@ -373,7 +383,12 @@ public class Libp2pService {
             }
             try {
                 if (msg.readableBytes() < 4) return;
+                msg.markReaderIndex();
                 int len = msg.readIntLE();
+                if (msg.readableBytes() < len) {
+                    msg.resetReaderIndex();
+                    return;
+                }
                 if (len > 1_000_000) {
                     log.warn("libp2p inbound failed: length {} exceeds limit", len);
                     ctx.close();


### PR DESCRIPTION
## Summary
- handle partial frames in `Libp2pService` to avoid `readerIndex`/`writerIndex` errors

## Testing
- `./gradlew test --no-daemon`
- `cd ui && npm test --silent <<'EOF'
q
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878f9b88b148326a9dd9c45e1b38779