### PR TITLE
Fix IPv6 multiaddr and tests

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
@@ -24,7 +24,15 @@ public class Peer {
 
     /** Multiaddr for libp2p connections. */
     public String multiAddr() {
-        String prefix = host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") ? "/ip4/" : "/dns4/";
+        String prefix;
+        if (host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            prefix = "/ip4/";
+        } else if (host.contains(":")) {
+            prefix = "/ip6/";
+        } else {
+            // default to IPv4 DNS name since compose services resolve to IPv4
+            prefix = "/dns4/";
+        }
         String base = prefix + host + "/tcp/" + port;
         return id == null ? base : base + "/p2p/" + id;
     }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
@@ -26,6 +26,12 @@ class PeerTest {
     }
 
     @Test
+    void multiAddrUsesIp6ForColonAddresses() {
+        Peer p = new Peer("::1", 4001);
+        assertEquals("/ip6/::1/tcp/4001", p.multiAddr());
+    }
+
+    @Test
     void fromStringParsesValid() {
         Peer p = Peer.fromString("host:1234");
         assertEquals("host", p.getHost());


### PR DESCRIPTION
## Summary
- improve detection of IPv4/IPv6/DNS when building libp2p multiaddrs
- add test case for IPv6
- revert DNS prefix to `/dns4/` to restore peer discovery

## Testing
- `./gradlew test --no-daemon --console plain`

------
https://chatgpt.com/codex/tasks/task_e_68792dd1bd988326ac4d3f6a3056e2b3