### PR TITLE
Fix peer discovery timeout and improve libp2p errors

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
@@ -24,7 +24,15 @@ public class Peer {
 
     /** Multiaddr for libp2p connections. */
     public String multiAddr() {
-        String prefix = host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") ? "/ip4/" : "/dns4/";
+        String prefix;
+        if (host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            prefix = "/ip4/";
+        } else if (host.contains(":")) {
+            prefix = "/ip6/";
+        } else {
+            // default to IPv4 DNS name since compose services resolve to IPv4
+            prefix = "/dns4/";
+        }
         String base = prefix + host + "/tcp/" + port;
         return id == null ? base : base + "/p2p/" + id;
     }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -193,7 +193,7 @@ public class Libp2pService {
                 }).join();
             return fut.get(5, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.warn("libp2p request failed: {}", e.getMessage());
+            log.warn("libp2p request failed", e);
             return new BlocksDto(java.util.List.of());
         }
     }
@@ -342,7 +342,7 @@ public class Libp2pService {
             byte[] data = buf.array();
             fut.thenAccept(s -> s.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(data))).join();
         } catch (Exception e) {
-            log.warn("libp2p send failed: {}", e.getMessage());
+            log.warn("libp2p send failed", e);
         }
     }
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -35,7 +35,8 @@ public class PeerService {
     private static final long RETRY_LIMIT_MS = java.util.concurrent.TimeUnit.MINUTES.toMillis(15);
 
     /** initial connection attempts during startup */
-    private static final int MAX_INIT_ATTEMPTS = 12;
+    // allow peers more time to start up before giving up
+    private static final int MAX_INIT_ATTEMPTS = 20;
 
     @PostConstruct
     public void init() {

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
@@ -26,6 +26,12 @@ class PeerTest {
     }
 
     @Test
+    void multiAddrUsesIp6ForColonAddresses() {
+        Peer p = new Peer("::1", 4001);
+        assertEquals("/ip6/::1/tcp/4001", p.multiAddr());
+    }
+
+    @Test
     void fromStringParsesValid() {
         Peer p = Peer.fromString("host:1234");
         assertEquals("host", p.getHost());


### PR DESCRIPTION
## Summary
- increase initial peer resolution attempts to reduce startup warnings
- include stack traces when libp2p requests or sends fail

## Testing
- `./gradlew test --no-daemon --console plain`


------
https://chatgpt.com/codex/tasks/task_e_68792dd1bd988326ac4d3f6a3056e2b3