### PR TITLE
Fix peer discovery timeout and improve libp2p errors

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/model/Block.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/Block.java
@@ -7,6 +7,8 @@ import java.util.List;
 import blockchain.core.crypto.HashingUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A full block = immutable header + transaction list.
@@ -28,12 +30,13 @@ public class Block implements java.io.Serializable {
     }
 
     /* ── extended ctor (genesis, determin. tests) ───────────────────── */
-    public Block(int  height,
-                 String prevHashHex,
-                 List<Transaction> txs,
-                 int  compactBits,
-                 long fixedTimeMillis,
-                 int  fixedNonce) {
+    @JsonCreator
+    public Block(@JsonProperty("height") int height,
+                 @JsonProperty("previousHashHex") String prevHashHex,
+                 @JsonProperty("txList") List<Transaction> txs,
+                 @JsonProperty("compactDifficultyBits") int compactBits,
+                 @JsonProperty("timeMillis") long fixedTimeMillis,
+                 @JsonProperty("nonce") int fixedNonce) {
 
         String merkle = HashingUtils.computeMerkleRoot(
                 txs.stream().map(Transaction::calcHashHex).toList());
@@ -56,6 +59,7 @@ public class Block implements java.io.Serializable {
         }
     }
 
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean isProofValid() { return header.isProofValid(); }
 
     /* ── delegates keep external API unchanged ─────────────────────── */

--- a/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
@@ -4,6 +4,9 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import blockchain.core.crypto.HashingUtils;
 
 /**
@@ -34,12 +37,13 @@ public final class BlockHeader implements java.io.Serializable {
              compactBits, Instant.now().toEpochMilli(), 0);
     }
 
-    public BlockHeader(int height,
-                       String prevHashHex,
-                       String merkleRootHex,
-                       int compactBits,
-                       long fixedTimeMillis,
-                       int  fixedNonce) {
+    @JsonCreator
+    public BlockHeader(@JsonProperty("height") int height,
+                       @JsonProperty("previousHashHex") String prevHashHex,
+                       @JsonProperty("merkleRootHex") String merkleRootHex,
+                       @JsonProperty("compactDifficultyBits") int compactBits,
+                       @JsonProperty("timeMillis") long fixedTimeMillis,
+                       @JsonProperty("nonce") int fixedNonce) {
         this.height                = height;
         this.previousHashHex       = prevHashHex;
         this.merkleRootHex         = merkleRootHex;
@@ -58,6 +62,7 @@ public final class BlockHeader implements java.io.Serializable {
         hashHex = computeHash();
     }
 
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean isProofValid() {
         BigInteger target = HashingUtils.compactToTarget(compactDifficultyBits);
         BigInteger val    = new BigInteger(1, HashingUtils.computeSha256Bytes(hashPreimage()));

--- a/blockchain-core/src/main/java/blockchain/core/serialization/JsonUtils.java
+++ b/blockchain-core/src/main/java/blockchain/core/serialization/JsonUtils.java
@@ -18,7 +18,8 @@ public final class JsonUtils {
     /** ⚠ MUST remain non-final so it can be swapped at runtime. */
     private static volatile ObjectMapper mapper = new ObjectMapper()
             .findAndRegisterModules()               // picks up all Jackson modules on classpath
-            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private JsonUtils() {
         /* utility class – no instances */

--- a/blockchain-core/src/test/java/simple/blockchain/model/BlockJsonTest.java
+++ b/blockchain-core/src/test/java/simple/blockchain/model/BlockJsonTest.java
@@ -1,0 +1,30 @@
+package simple.blockchain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import blockchain.core.model.Block;
+import blockchain.core.model.Transaction;
+import blockchain.core.model.Wallet;
+import blockchain.core.serialization.JsonUtils;
+
+/** Verify Block JSON round-trips using the public constructors. */
+class BlockJsonTest {
+    @Test
+    void blockSerializesAndDeserializes() {
+        Wallet w = new Wallet();
+        Transaction coinbase = new Transaction(w.getPublicKey(), 5.0, "0");
+        Block b = new Block(1, "0", List.of(coinbase), 0x1f0fffff, 0L, 0);
+
+        String json = JsonUtils.toJson(b);
+        Block parsed = JsonUtils.blockFromJson(json);
+
+        assertEquals(b.getHeight(), parsed.getHeight());
+        assertEquals(b.getPreviousHashHex(), parsed.getPreviousHashHex());
+        assertEquals(b.getMerkleRootHex(), parsed.getMerkleRootHex());
+        assertEquals(b.getNonce(), parsed.getNonce());
+    }
+}

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
@@ -24,7 +24,15 @@ public class Peer {
 
     /** Multiaddr for libp2p connections. */
     public String multiAddr() {
-        String prefix = host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") ? "/ip4/" : "/dns4/";
+        String prefix;
+        if (host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            prefix = "/ip4/";
+        } else if (host.contains(":")) {
+            prefix = "/ip6/";
+        } else {
+            // generic DNS so both IPv4 and IPv6 work
+            prefix = "/dns/";
+        }
         String base = prefix + host + "/tcp/" + port;
         return id == null ? base : base + "/p2p/" + id;
     }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -193,7 +193,7 @@ public class Libp2pService {
                 }).join();
             return fut.get(5, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.warn("libp2p request failed: {}", e.getMessage());
+            log.warn("libp2p request failed", e);
             return new BlocksDto(java.util.List.of());
         }
     }
@@ -342,7 +342,7 @@ public class Libp2pService {
             byte[] data = buf.array();
             fut.thenAccept(s -> s.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(data))).join();
         } catch (Exception e) {
-            log.warn("libp2p send failed: {}", e.getMessage());
+            log.warn("libp2p send failed", e);
         }
     }
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -35,7 +35,8 @@ public class PeerService {
     private static final long RETRY_LIMIT_MS = java.util.concurrent.TimeUnit.MINUTES.toMillis(15);
 
     /** initial connection attempts during startup */
-    private static final int MAX_INIT_ATTEMPTS = 12;
+    // allow peers more time to start up before giving up
+    private static final int MAX_INIT_ATTEMPTS = 20;
 
     @PostConstruct
     public void init() {

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
@@ -16,13 +16,19 @@ class PeerTest {
     @Test
     void multiAddrUsesDnsForHostnames() {
         Peer p = new Peer("example.com", 4001);
-        assertEquals("/dns4/example.com/tcp/4001", p.multiAddr());
+        assertEquals("/dns/example.com/tcp/4001", p.multiAddr());
     }
 
     @Test
     void multiAddrUsesIp4ForNumericHosts() {
         Peer p = new Peer("1.2.3.4", 4001);
         assertEquals("/ip4/1.2.3.4/tcp/4001", p.multiAddr());
+    }
+
+    @Test
+    void multiAddrUsesIp6ForColonAddresses() {
+        Peer p = new Peer("::1", 4001);
+        assertEquals("/ip6/::1/tcp/4001", p.multiAddr());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- increase initial peer resolution attempts to reduce startup warnings
- include stack traces when libp2p requests or sends fail
- add Jackson annotations to deserialize Block and BlockHeader
- ignore unknown properties in JsonUtils and add unit test
- use generic dns prefix for peer multiaddrs

## Testing
- `./gradlew test --no-daemon --console plain`

------
https://chatgpt.com/codex/tasks/task_e_68792dd1bd988326ac4d3f6a3056e2b3