### PR TITLE
Fix block deserialization and peer sync

### DIFF
--- a/blockchain-core/src/main/java/blockchain/core/model/Block.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/Block.java
@@ -4,6 +4,9 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import blockchain.core.crypto.HashingUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +20,16 @@ public class Block implements java.io.Serializable {
 
     private final BlockHeader       header;
     private final List<Transaction> txList;
+
+    /* ------------------------------------------------------------------ */
+    /* JSON constructor                                                   */
+    /* ------------------------------------------------------------------ */
+    @JsonCreator
+    public Block(@JsonProperty("header") BlockHeader header,
+                 @JsonProperty("txList") List<Transaction> txList) {
+        this.header = header;
+        this.txList = List.copyOf(txList);
+    }
 
     /* ── public ctor used by code & tests ───────────────────────────── */
     public Block(int height,

--- a/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
+++ b/blockchain-core/src/main/java/blockchain/core/model/BlockHeader.java
@@ -4,6 +4,9 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import blockchain.core.crypto.HashingUtils;
 
 /**
@@ -34,12 +37,13 @@ public final class BlockHeader implements java.io.Serializable {
              compactBits, Instant.now().toEpochMilli(), 0);
     }
 
-    public BlockHeader(int height,
-                       String prevHashHex,
-                       String merkleRootHex,
-                       int compactBits,
-                       long fixedTimeMillis,
-                       int  fixedNonce) {
+    @JsonCreator
+    public BlockHeader(@JsonProperty("height") int height,
+                       @JsonProperty("previousHashHex") String prevHashHex,
+                       @JsonProperty("merkleRootHex") String merkleRootHex,
+                       @JsonProperty("compactDifficultyBits") int compactBits,
+                       @JsonProperty("timeMillis") long fixedTimeMillis,
+                       @JsonProperty("nonce") int  fixedNonce) {
         this.height                = height;
         this.previousHashHex       = prevHashHex;
         this.merkleRootHex         = merkleRootHex;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/SyncService.java
@@ -16,21 +16,10 @@ public class SyncService {
 
     private final NodeService  node;
     private final Libp2pService libp2p;
-    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER = new com.fasterxml.jackson.databind.ObjectMapper()
-            .registerModule(new com.fasterxml.jackson.module.paramnames.ParameterNamesModule())
-            .addMixIn(blockchain.core.model.Block.class, BlockMixIn.class)
-            .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .findAndRegisterModules();
-
-    private abstract static class BlockMixIn {
-        @com.fasterxml.jackson.annotation.JsonCreator
-        BlockMixIn(@com.fasterxml.jackson.annotation.JsonProperty("height") int height,
-                   @com.fasterxml.jackson.annotation.JsonProperty("prevHashHex") String prev,
-                   @com.fasterxml.jackson.annotation.JsonProperty("txs") java.util.List<blockchain.core.model.Transaction> txs,
-                   @com.fasterxml.jackson.annotation.JsonProperty("compactBits") int bits,
-                   @com.fasterxml.jackson.annotation.JsonProperty("fixedTimeMillis") long time,
-                   @com.fasterxml.jackson.annotation.JsonProperty("fixedNonce") int nonce) {}
-    }
+    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER =
+            new com.fasterxml.jackson.databind.ObjectMapper()
+                    .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .findAndRegisterModules();
 
     /**
      * Fetch blocks from {@code peer} until no newer blocks are returned.

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SyncServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/SyncServiceTest.java
@@ -19,9 +19,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import blockchain.core.serialization.JsonUtils;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import blockchain.core.model.Transaction;
 
 import java.util.List;
 
@@ -36,21 +33,9 @@ public class SyncServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.addMixIn(blockchain.core.model.Block.class, BlockMixIn.class);
-        mapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
         JsonUtils.use(mapper);
         svc = new SyncService(node, libp2p);
-    }
-
-    private abstract static class BlockMixIn {
-        @JsonCreator
-        BlockMixIn(@JsonProperty("height") int height,
-                   @JsonProperty("prevHashHex") String prev,
-                   @JsonProperty("txs") java.util.List<Transaction> txs,
-                   @JsonProperty("compactBits") int bits,
-                   @JsonProperty("fixedTimeMillis") long time,
-                   @JsonProperty("fixedNonce") int nonce) {}
     }
 
     @Test
@@ -61,8 +46,8 @@ public class SyncServiceTest {
         Block b2 = new Block(2, "h2", List.of(new Transaction()), 0);
 
         when(node.latestBlock()).thenReturn(genesis, b2, b2);
-        String j1 = "{\"height\":1,\"prevHashHex\":\"h1\",\"txs\":[],\"compactBits\":0,\"fixedTimeMillis\":0,\"fixedNonce\":0}";
-        String j2 = "{\"height\":2,\"prevHashHex\":\"h2\",\"txs\":[],\"compactBits\":0,\"fixedTimeMillis\":0,\"fixedNonce\":0}";
+        String j1 = JsonUtils.toJson(b1);
+        String j2 = JsonUtils.toJson(b2);
         when(libp2p.requestBlocks(eq(peer), any(GetBlocksDto.class)))
                 .thenReturn(new BlocksDto(List.of(j1, j2)), new BlocksDto(List.of()));
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -61,9 +61,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 24
-    depends_on:
-      backend1:
-        condition: service_healthy
   frontend2:
     build:
       context: ./ui


### PR DESCRIPTION
## Summary
- ensure `Block` and `BlockHeader` can be read from JSON
- remove libp2p mixin usage in SyncService
- update SyncServiceTest for new JSON layout
- start backend2 independently in CI compose

## Testing
- `./gradlew clean jacocoTestReport`
- `behave pipeline-tests` *(fails: gRPC service on port 9090 not ready)*

------
https://chatgpt.com/codex/tasks/task_e_68795f78d9d08326bffcb0fa27f9bd89