### PR TITLE
Fix Docker health checks and stabilize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,7 @@ jobs:
       run: |
         docker compose -f docker-compose.ci.yml up -d --build
         docker compose -f docker-compose.ci.yml ps
-        for i in {1..40}; do
-          if docker compose -f docker-compose.ci.yml ps | grep -q "healthy"; then
-            break
-          fi
-          sleep 5
-        done
+        ./scripts/check_compose_health.sh
 
     - name: Dump logs if compose failed
       if: failure() && steps.compose.outcome == 'failure'
@@ -88,7 +83,7 @@ jobs:
     - name: Run end-to-end tests
       run: |
         pip install selenium requests PyJWT behave grpcio protobuf
-        FLAKY_RETRY=1 behave pipeline-tests/e2e.feature
+        behave pipeline-tests/e2e.feature
 
     - name: Dump logs on test failure
       if: failure()

--- a/AGENTS_LOG.md
+++ b/AGENTS_LOG.md
@@ -1,0 +1,5 @@
+## Health check stabilization
+- Replaced incorrect $$SERVER_PORT references in docker-compose.ci.yml.
+- Added readiness probes via Spring Boot property.
+- Introduced scripts/check_compose_health.sh to verify container health.
+- Removed FLAKY_RETRY handling and updated tests and docs accordingly.

--- a/PIPELINE_PLAN.md
+++ b/PIPELINE_PLAN.md
@@ -2,6 +2,6 @@ This file tracks the major steps used to refactor the CI pipeline.
 
 1. Review existing workflow and scripts.
 2. Increase startup wait loop to 40 checks to handle slow containers.
-3. Enable flaky retry handling via FLAKY_RETRY for end-to-end tests.
+3. Replace flaky retry handling with stricter health checks and readiness probes.
 4. Align `ci-local.sh` with the workflow so local runs mirror CI.
 5. Update documentation to explain the environment variables and new behavior.

--- a/README.md
+++ b/README.md
@@ -130,11 +130,9 @@ Node, caches dependencies and then packages the Spring Boot app with
 `bootJar`. Selenium is started alongside the services for a full integration
 test. Each backend container declares `SERVER_PORT` so the health checks run
 inside Docker Compose succeed.
-Backend2 now waits for backend1's health endpoint before it starts so the
-initial peer connection is reliable.
-The workflow waits up to forty health checks before running end-to-end tests
-to accommodate slow CI runners. If mining occasionally times out, the tests
-retry when the `FLAKY_RETRY=1` environment variable is set.
+Backend2 now relies on Compose's `service_healthy` condition, removing the
+custom wait loop. The workflow waits for all containers to report `healthy`
+using `scripts/check_compose_health.sh` before executing the end-to-end tests.
 
 ## Contributing
 
@@ -147,9 +145,8 @@ Execute the same checks that GitHub Actions runs with:
 ```bash
 make ci-local
 ```
-The script builds the runtime image, starts the Compose setup and sets
-`FLAKY_RETRY=1` so the end-to-end scenario is resilient to transient mining
-timeouts.
+The script builds the runtime image, starts the Compose setup and runs the
+pipeline tests without additional retries.
 
 ## Roadmap
 

--- a/blockchain-node/src/main/resources/application.yml
+++ b/blockchain-node/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     banner-mode: off
 
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
   endpoints:
     web:
       exposure:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -19,10 +19,10 @@ services:
       - ./data1:/app/data1
       - ./wallet1:/root/.simple-chain
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://localhost:$$SERVER_PORT/actuator/health/p2p >/dev/null"]
+      test: ["CMD", "curl", "-fs", "http://localhost:3333/actuator/health"]
       interval: 5s
       timeout: 5s
-      retries: 24
+      retries: 12
   frontend1:
     build:
       context: ./ui
@@ -40,10 +40,9 @@ services:
 
   backend2:
     image: simple-blockchain-node:runtime
-    entrypoint: >-
-      sh -c 'until curl -fs http://backend1:3333/actuator/health/p2p >/dev/null; do sleep 2; done; exec java -jar app.jar'
     depends_on:
-      - backend1
+      backend1:
+        condition: service_healthy
     environment:
       SERVER_PORT: 3334
       NODE_LIBP2P_PORT: 4002
@@ -61,10 +60,10 @@ services:
       - ./data2:/app/data2
       - ./wallet2:/root/.simple-chain
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://localhost:$$SERVER_PORT/actuator/health/p2p >/dev/null"]
+      test: ["CMD", "curl", "-fs", "http://localhost:3334/actuator/health"]
       interval: 5s
       timeout: 5s
-      retries: 24
+      retries: 12
   frontend2:
     build:
       context: ./ui

--- a/pipeline-tests/e2e.feature
+++ b/pipeline-tests/e2e.feature
@@ -1,7 +1,8 @@
 Feature: Multi-node synchronization
 
   Scenario: Mining and sync between nodes
-    Given two nodes are running
+    Given docker compose services are healthy
+    And two nodes are running
     When I mine a block on node1
     Then node2 should synchronize the block
     And node1 should have a positive balance

--- a/scripts/check_compose_health.sh
+++ b/scripts/check_compose_health.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.ci.yml}
+ATTEMPTS=40
+
+for ((i=1;i<=ATTEMPTS;i++)); do
+    all_healthy=true
+    for c in $(docker compose -f "$COMPOSE_FILE" ps -q); do
+        status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}unknown{{end}}' "$c" 2>/dev/null || echo unknown)
+        if [ "$status" != "healthy" ]; then
+            all_healthy=false
+            break
+        fi
+    done
+    if [ "$all_healthy" = true ]; then
+        echo "All services healthy after $i checks"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "Services did not become healthy in time" >&2
+docker compose -f "$COMPOSE_FILE" ps || true
+docker compose -f "$COMPOSE_FILE" logs || true
+exit 1

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -16,18 +16,12 @@ popd > /dev/null
 docker build -t simple-blockchain-node:runtime -f Dockerfile.backend .
 COMPOSE_FILE=docker-compose.ci.yml
 docker compose -f $COMPOSE_FILE up -d --build
-
 # Wait for containers to become healthy
-for i in {1..40}; do
-  if docker compose -f $COMPOSE_FILE ps | grep -q "healthy"; then
-    break
-  fi
-  sleep 5
-done
+./scripts/check_compose_health.sh
 
 # Run end-to-end tests
 pip install selenium requests PyJWT behave grpcio protobuf
-FLAKY_RETRY=1 behave pipeline-tests/e2e.feature
+behave pipeline-tests/e2e.feature
 STATUS=$?
 
 docker compose -f $COMPOSE_FILE down


### PR DESCRIPTION
## Summary
- fix health check curl commands in docker-compose.ci.yml
- use Docker compose health dependency instead of entrypoint wait loop
- enable Spring Boot readiness probes
- add script to await healthy containers
- integrate script into CI workflow and local script
- remove FLAKY_RETRY handling in tests and docs
- update pipeline documentation
- log health check stabilization in AGENTS_LOG

## Testing
- `./gradlew clean build`
- `docker compose -f docker-compose.ci.yml up -d --build` *(fails: command not found)*
- `behave pipeline-tests/e2e.feature` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b936593d08326b3180a5afb620fd5