### PR TITLE
Implement handshake v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Set `NODE_GRPC_PORT` to expose the same endpoints over gRPC (defaults to `9090`)
 
 ## P2P protocol
 
-The node announces itself on `/simple-blockchain/*`. All handshake data is encoded using the protobuf definitions in `p2p.proto`.
+The node announces itself on `/simple-blockchain/*`. All handshake data is encoded using the protobuf definitions in `p2p.proto`. Handshakes now include the libp2p peer ID and REST port so peers can connect without extra HTTP lookups.
 
 - Control – peer list, find-node, range sync
 - Blocks  – single block messages

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/HandshakeDto.java
@@ -9,10 +9,14 @@ package de.flashyotter.blockchain_node.dto;
  * each side simply ignores the duplicate.
  *
  * @param nodeId          arbitrary, human-friendly identifier
+ * @param peerId          base58 libp2p peer id of this node
  * @param protocolVersion semantic protocol version (major.minor.patch)
  * @param listenPort      TCP port the node is accepting peer connections on
+ * @param restPort        HTTP port for REST/gRPC endpoints
  */
 public record HandshakeDto(String nodeId,
+                           String peerId,
                            String protocolVersion,
-                           int listenPort)
+                           int listenPort,
+                           int restPort)
         implements P2PMessageDto { }

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/P2PProtoMapper.java
@@ -23,8 +23,10 @@ public final class P2PProtoMapper {
         if (dto instanceof HandshakeDto hs) {
             builder.setHandshake(Handshake.newBuilder()
                     .setNodeId(hs.nodeId())
+                    .setPeerId(hs.peerId())
                     .setProtocolVersion(hs.protocolVersion())
                     .setListenPort(hs.listenPort())
+                    .setRestPort(hs.restPort())
                     .build());
         } else if (dto instanceof NewBlockDto nb) {
             Block b = blockchain.core.serialization.JsonUtils.blockFromJson(nb.rawBlockJson());
@@ -60,8 +62,10 @@ public final class P2PProtoMapper {
         return switch (msg.getMsgCase()) {
             case HANDSHAKE -> new HandshakeDto(
                     msg.getHandshake().getNodeId(),
+                    msg.getHandshake().getPeerId(),
                     msg.getHandshake().getProtocolVersion(),
-                    msg.getHandshake().getListenPort());
+                    msg.getHandshake().getListenPort(),
+                    msg.getHandshake().getRestPort());
             case NEWBLOCK -> new NewBlockDto(
                     blockchain.core.serialization.JsonUtils.toJson(
                             GrpcMapper.fromProto(msg.getNewBlock().getBlock())));

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -10,7 +10,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import de.flashyotter.blockchain_node.service.NodeService;
 import de.flashyotter.blockchain_node.service.KademliaService;
-import org.springframework.web.reactive.function.client.WebClient;
 import io.libp2p.core.Host;
 import io.libp2p.etc.SimpleClientHandler;
 import io.libp2p.etc.SimpleClientHandlerKt;
@@ -37,17 +36,14 @@ public class Libp2pService {
     private final NodeProperties props;
     private final NodeService node;
     private final KademliaService kademlia;
-    private final WebClient webClient;
 
     public Libp2pService(Host host, NodeProperties props,
                          @org.springframework.context.annotation.Lazy NodeService node,
-                         KademliaService kademlia,
-                         WebClient webClient) {
+                         KademliaService kademlia) {
         this.host = host;
         this.props = props;
         this.node = node;
         this.kademlia = kademlia;
-        this.webClient = webClient;
     }
 
     private volatile String publicAddr;
@@ -259,30 +255,7 @@ public class Libp2pService {
                     }
                     if (ctx.channel().remoteAddress() instanceof java.net.InetSocketAddress isa) {
                         String host = isa.getAddress().getHostAddress();
-                        String peerId = null;
-                        int httpPort = hs.listenPort() - (props.getLibp2pPort() - props.getPort());
-                        for (int i = 0; i < 5 && peerId == null; i++) {
-                            try {
-                                PeerIdDto dtoId = webClient.get()
-                                        .uri("http://" + host + ':' + httpPort + "/node/peer-id")
-                                        .retrieve()
-                                        .bodyToMono(PeerIdDto.class)
-                                        .block(java.time.Duration.ofSeconds(3));
-                                if (dtoId != null) peerId = dtoId.peerId();
-                            } catch (Exception ex) {
-                                try {
-                                    Thread.sleep(1000);
-                                } catch (InterruptedException ie) {
-                                    Thread.currentThread().interrupt();
-                                    break;
-                                }
-                            }
-                        }
-                        if (peerId == null) {
-                            log.warn("Failed to resolve peer id for {}:{}", host, httpPort);
-                            return;
-                        }
-                        kademlia.store(new Peer(host, hs.listenPort(), peerId));
+                        kademlia.store(new Peer(host, hs.listenPort(), hs.peerId()));
                     }
                 } else if (dto instanceof FindNodeDto find) {
                     var nearest = kademlia.closest(find.nodeId(), 16)

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/DiscoveryLoop.java
@@ -26,8 +26,10 @@ public class DiscoveryLoop {
             libp2p.send(p, new de.flashyotter.blockchain_node.dto.FindNodeDto(kademlia.selfId()));
             libp2p.send(p, new de.flashyotter.blockchain_node.dto.HandshakeDto(
                     kademlia.selfId(),
+                    libp2p.peerId(),
                     libp2p.protocolVersion(),
-                    props.getLibp2pPort()));
+                    props.getLibp2pPort(),
+                    props.getPort()));
         }
     }
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/PeerService.java
@@ -3,13 +3,10 @@ package de.flashyotter.blockchain_node.service;
 import de.flashyotter.blockchain_node.config.NodeProperties;
 import de.flashyotter.blockchain_node.p2p.Peer;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
-import de.flashyotter.blockchain_node.dto.PeerIdDto;
 import de.flashyotter.blockchain_node.dto.FindNodeDto;
 import de.flashyotter.blockchain_node.dto.HandshakeDto;
-import org.springframework.web.reactive.function.client.WebClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.scheduling.annotation.Scheduled;
 import reactor.core.scheduler.Schedulers;
 import jakarta.annotation.PostConstruct;          // ← switched to Jakarta namespace
 
@@ -26,68 +23,23 @@ public class PeerService {
     private final P2PBroadcastService  broadcaster;
     private final KademliaService      kademlia;
     private final de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService libp2p;
-    private final WebClient            webClient;
-
-    /** peers without a resolved id mapped to first-seen timestamp */
-    private final java.util.Map<Peer, Long> unresolved =
-            new java.util.concurrent.ConcurrentHashMap<>();
-
-    /** give up resolving a peer after this many minutes */
-    private static final long RETRY_LIMIT_MS = java.util.concurrent.TimeUnit.MINUTES.toMillis(15);
 
     /** initial connection attempts during startup */
-    // allow peers more time to start up before giving up
-    // Allow more time for peers to come online before giving up
     private static final int MAX_INIT_ATTEMPTS = 40;
 
     @PostConstruct
     public void init() {
-        int offset = props.getLibp2pPort() - props.getPort();
         props.getPeers().forEach(addr -> {
             var sp = addr.split(":");
             String host = sp[0];
             int port = Integer.parseInt(sp[1]);
             Peer peer = new Peer(host, port);
-            if (!resolvePeerId(peer, MAX_INIT_ATTEMPTS)) {
-                org.slf4j.LoggerFactory.getLogger(PeerService.class)
-                        .warn("Failed to resolve peer id for {}:{} after waiting", host, port - offset);
-                unresolved.put(peer, System.currentTimeMillis());
-            }
+            registry.add(peer);
+            kademlia.store(peer);
+            postAdd(peer);
         });
 
         broadcaster.broadcastPeerList();
-    }
-
-    private boolean resolvePeerId(Peer peer, int attempts) {
-        int offset = props.getLibp2pPort() - props.getPort();
-        String host = peer.getHost();
-        int port = peer.getPort();
-        int httpPort = port - offset;
-        PeerIdDto dto = null;
-        for (int i = 0; i < attempts && dto == null; i++) {
-            try {
-                dto = webClient.get()
-                        .uri("http://" + host + ':' + httpPort + "/node/peer-id")
-                        .retrieve()
-                        .bodyToMono(PeerIdDto.class)
-                        .block(java.time.Duration.ofSeconds(3));
-            } catch (Exception e) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
-        }
-        if (dto == null) {
-            return false;
-        }
-        Peer withId = new Peer(host, port, dto.peerId());
-        registry.add(withId);
-        kademlia.store(withId);
-        postAdd(withId);
-        return true;
     }
 
     private void postAdd(Peer p) {
@@ -97,21 +49,9 @@ public class PeerService {
         libp2p.send(p, new FindNodeDto(kademlia.selfId()));
         libp2p.send(p, new HandshakeDto(
                 props.getId(),
+                libp2p.peerId(),
                 libp2p.protocolVersion(),
-                props.getLibp2pPort()));
-    }
-
-    // Retry more aggressively so newly started peers join within a few seconds
-    @Scheduled(fixedDelay = 5000)
-    public void retryMissingPeers() {
-        long now = System.currentTimeMillis();
-        unresolved.forEach((peer, since) -> {
-            if (now - since > RETRY_LIMIT_MS) {
-                unresolved.remove(peer);
-            } else if (resolvePeerId(peer, 3)) {
-                unresolved.remove(peer);
-                broadcaster.broadcastPeerList();
-            }
-        });
+                props.getLibp2pPort(),
+                props.getPort()));
     }
 }

--- a/blockchain-node/src/main/proto/p2p.proto
+++ b/blockchain-node/src/main/proto/p2p.proto
@@ -9,8 +9,10 @@ import "node.proto";
 
 message Handshake {
   string nodeId = 1;
-  string protocolVersion = 2;
-  int32 listenPort = 3;
+  string peerId = 2;
+  string protocolVersion = 3;
+  int32 listenPort = 4;
+  int32 restPort = 5;
 }
 
 message NewBlock {

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pAutoNatTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pAutoNatTest.java
@@ -34,9 +34,9 @@ class Libp2pAutoNatTest {
                 p -> p.toString().getBytes(StandardCharsets.UTF_8), p -> 0);
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
-        WebClient client = WebClient.builder().build();
+        WebClient client = WebClient.builder().build(); // unused
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         svc.discoverPublicAddr(new Peer("dummy", 1));
 
         assertEquals(addr.toString(), svc.getPublicAddr());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pHandshakeTest.java
@@ -41,9 +41,9 @@ class Libp2pHandshakeTest {
                                 .header("Content-Type", "application/json")
                                 .body("{\"peerId\":\"id-123\"}")
                                 .build());
-        WebClient client = WebClient.builder().exchangeFunction(fx).build();
+        WebClient client = WebClient.builder().exchangeFunction(fx).build(); // unused
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());
         ctor.setAccessible(true);
@@ -51,7 +51,7 @@ class Libp2pHandshakeTest {
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
-                new HandshakeDto("x","0.0.1",0));
+                new HandshakeDto("x","peer1","0.0.1",0,0));
         byte[] data = msg.toByteArray();
         ByteBuf buf = Unpooled.buffer(4 + data.length).writeIntLE(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
@@ -82,9 +82,9 @@ class Libp2pHandshakeTest {
                                 .header("Content-Type", "application/json")
                                 .body("{\"peerId\":\"id-456\"}")
                                 .build());
-        WebClient client = WebClient.builder().exchangeFunction(fx2).build();
+        WebClient client = WebClient.builder().exchangeFunction(fx2).build(); // unused
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());
         ctor.setAccessible(true);
@@ -97,7 +97,7 @@ class Libp2pHandshakeTest {
         when(ch.remoteAddress()).thenReturn(addr);
 
         var msg = de.flashyotter.blockchain_node.p2p.P2PProtoMapper.toProto(
-                new HandshakeDto("x","1.0.0",7000));
+                new HandshakeDto("x","peer2","1.0.0",7000,7001));
         byte[] data = msg.toByteArray();
         ByteBuf buf = Unpooled.buffer(4 + data.length).writeIntLE(data.length).writeBytes(data);
         when(ctx.close()).thenReturn(null);
@@ -107,6 +107,6 @@ class Libp2pHandshakeTest {
         method.invoke(handler, ctx, buf);
 
         verify(ctx, never()).close();
-        assertTrue(reg.all().contains(new Peer("1.2.3.4", 7000, "id-456")));
+        assertTrue(reg.all().contains(new Peer("1.2.3.4", 7000, "peer2")));
     }
 }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pKademliaHandlerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pKademliaHandlerTest.java
@@ -39,9 +39,9 @@ class Libp2pKademliaHandlerTest {
         PeerRegistry reg = new PeerRegistry();
         KademliaService kad = new KademliaService(table, reg, props);
         kad.store(new Peer("x", 1));
-        WebClient client = WebClient.builder().build();
+        WebClient client = WebClient.builder().build(); // unused
 
-        Libp2pService svc = new Libp2pService(host, props, node, kad, client);
+        Libp2pService svc = new Libp2pService(host, props, node, kad);
         // instantiate handler via reflection
         var cls = Class.forName(Libp2pService.class.getName() + "$ControlHandler");
         var ctor = cls.getDeclaredConstructor(svc.getClass());

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/Libp2pServiceBroadcastTest.java
@@ -90,10 +90,10 @@ class Libp2pServiceBroadcastTest {
                 p -> p.toString().getBytes(StandardCharsets.UTF_8), p -> 0);
         KademliaService k1 = new KademliaService(t1, r1, props1);
         KademliaService k2 = new KademliaService(t2, r2, props2);
-        WebClient client = WebClient.builder().build();
+        WebClient client = WebClient.builder().build(); // unused
 
-        s1 = new Libp2pService(h1, props1, n1, k1, client);
-        s2 = new Libp2pService(h2, props2, n2, k2, client);
+        s1 = new Libp2pService(h1, props1, n1, k1);
+        s2 = new Libp2pService(h2, props2, n2, k2);
         s1.init();
         s2.init();
     }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerServiceTest.java
@@ -20,9 +20,7 @@ import de.flashyotter.blockchain_node.service.PeerService;
 import de.flashyotter.blockchain_node.service.SyncService;
 import de.flashyotter.blockchain_node.service.KademliaService;
 import de.flashyotter.blockchain_node.p2p.libp2p.Libp2pService;
-import org.springframework.web.reactive.function.client.WebClient;
 import de.flashyotter.blockchain_node.dto.FindNodeDto;
-import de.flashyotter.blockchain_node.dto.PeerIdDto;
 import reactor.core.publisher.Flux;
 
 class PeerServiceTest {
@@ -42,8 +40,6 @@ class PeerServiceTest {
     @Mock
     private Libp2pService libp2p;
 
-    private WebClient webClient;
-
 
     private PeerService svc;
     private NodeProperties props;
@@ -54,14 +50,7 @@ class PeerServiceTest {
         props = new NodeProperties();
         // set two peers
         props.setPeers(java.util.List.of("one:100", "two:200"));
-        webClient = Mockito.mock(WebClient.class, Mockito.RETURNS_DEEP_STUBS);
-        when(webClient.get()
-                .uri(Mockito.anyString())
-                .retrieve()
-                .bodyToMono(Mockito.eq(PeerIdDto.class)))
-            .thenReturn(reactor.core.publisher.Mono.just(new PeerIdDto("id")));
-
-        svc = new PeerService(props, sync, reg, broad, kademlia, libp2p, webClient);
+        svc = new PeerService(props, sync, reg, broad, kademlia, libp2p);
     }
 
     @Test
@@ -72,14 +61,14 @@ class PeerServiceTest {
         svc.init();
 
         // registry.add for each peer string
-        verify(reg).add(new Peer("one", 100, "id"));
-        verify(reg).add(new Peer("two", 200, "id"));
-        verify(kademlia).store(new Peer("one", 100, "id"));
-        verify(kademlia).store(new Peer("two", 200, "id"));
+        verify(reg).add(new Peer("one", 100));
+        verify(reg).add(new Peer("two", 200));
+        verify(kademlia).store(new Peer("one", 100));
+        verify(kademlia).store(new Peer("two", 200));
 
         // followPeer called for each peer
-        verify(sync).followPeer(new Peer("one", 100, "id"));
-        verify(sync).followPeer(new Peer("two", 200, "id"));
+        verify(sync).followPeer(new Peer("one", 100));
+        verify(sync).followPeer(new Peer("two", 200));
         verify(libp2p, times(2)).send(any(Peer.class), any(FindNodeDto.class));
 
         // broadcastPeerList at end


### PR DESCRIPTION
## Summary
- extend handshake to include peer ID and REST port
- remove blocking HTTP peer-id lookup
- adjust services to send/handle the new fields
- clean up unused variable in PeerService

## Testing
- `./gradlew test`
- `cd ui && npm test -- --run`
- ❌ `docker compose -f docker-compose.ci.yml up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9d41b5748326987e12bd2a0b7d05