### PR TITLE
Improve startup order for libp2p nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,15 +67,26 @@ jobs:
     - name: Start Selenium container
       run: docker run -d --name selenium -p 4444:4444 selenium/standalone-chrome
 
-    - name: Build & start multi-node setup
-      id: compose
+    - name: Start backend1 and frontend1
+      id: compose1
       run: |
-        docker compose -f docker-compose.ci.yml up -d --build
+        docker compose -f docker-compose.ci.yml up -d --build backend1 frontend1
+        ./scripts/check_compose_health.sh
+
+    - name: Fetch peer id
+      run: |
+        PEER_ID=$(curl -s http://localhost:3333/node/peer-id | jq -r .peerId)
+        echo "BACKEND1_MULTIADDR=/dns4/backend1/tcp/4001/p2p/${PEER_ID}" >> $GITHUB_ENV
+
+    - name: Start backend2 and frontend2
+      id: compose2
+      run: |
+        docker compose -f docker-compose.ci.yml up -d backend2 frontend2
         docker compose -f docker-compose.ci.yml ps
         ./scripts/check_compose_health.sh
 
     - name: Dump logs if compose failed
-      if: failure() && steps.compose.outcome == 'failure'
+      if: failure() && steps.compose2.outcome == 'failure'
       run: |
         docker compose -f docker-compose.ci.yml ps
         docker compose -f docker-compose.ci.yml logs --no-color

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,7 @@ services:
     environment:
       SERVER_PORT: 3333
       NODE_LIBP2P_PORT: 4001
-      NODE_PEERS: "backend2:4002"
+      NODE_PEERS: ""
       NODE_JWT_SECRET: changeMeSuperSecret
       NODE_WALLET_PASSWORD: changeMeSuperSecret
       NODE_GRPC_PORT: 9090
@@ -46,7 +46,7 @@ services:
     environment:
       SERVER_PORT: 3334
       NODE_LIBP2P_PORT: 4002
-      NODE_PEERS: "backend1:4001"
+      NODE_PEERS: "${BACKEND1_MULTIADDR:-backend1:4001}"
       NODE_JWT_SECRET: changeMeSuperSecret
       NODE_WALLET_PASSWORD: changeMeSuperSecret
       NODE_GRPC_PORT: 9091

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -15,8 +15,13 @@ popd > /dev/null
 # Build runtime image and start multi-node setup
 docker build -t simple-blockchain-node:runtime -f Dockerfile.backend .
 COMPOSE_FILE=docker-compose.ci.yml
-docker compose -f $COMPOSE_FILE up -d --build
-# Wait for containers to become healthy
+# Start first node and frontend
+docker compose -f $COMPOSE_FILE up -d --build backend1 frontend1
+./scripts/check_compose_health.sh
+# Query peer ID of backend1 and start second node
+PEER_ID=$(curl -s http://localhost:3333/node/peer-id | jq -r .peerId)
+BACKEND1_MULTIADDR="/dns4/backend1/tcp/4001/p2p/${PEER_ID}"
+BACKEND1_MULTIADDR="$BACKEND1_MULTIADDR" docker compose -f $COMPOSE_FILE up -d backend2 frontend2
 ./scripts/check_compose_health.sh
 
 # Run end-to-end tests


### PR DESCRIPTION
## Summary
- sequentially start backend containers
- fetch backend1 peer id to build backend2 peers
- update Compose to use environment variable for backend2 peer address
- add same logic to `ci-local.sh`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687bad465d4c8326971bbafa42bc0d96