### PR TITLE
Add compose config regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "work" ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Python deps
+        run: |
+          pip install behave PyYAML grpcio selenium requests PyJWT protobuf
+      - name: Run CI script
+        run: |
+          make ci-local

--- a/pipeline-tests/compose_config.feature
+++ b/pipeline-tests/compose_config.feature
@@ -1,0 +1,5 @@
+Feature: Docker Compose configuration
+
+  Scenario: Node2 peers with node1
+    When I load the CI compose file
+    Then backend2 should configure NODE_PEERS

--- a/pipeline-tests/steps/regression_steps.py
+++ b/pipeline-tests/steps/regression_steps.py
@@ -22,3 +22,20 @@ def step_run(context, cmd):
 def step_success(context):
     if context.result.returncode != 0:
         raise AssertionError(context.output)
+
+import yaml
+
+@when('I load the CI compose file')
+def step_load_compose(context):
+    with open('docker-compose.ci.yml') as f:
+        context.compose = yaml.safe_load(f)
+
+@then('backend2 should configure NODE_PEERS')
+def step_check_peers(context):
+    services = context.compose.get('services', {})
+    backend2 = services.get('backend2', {})
+    env = backend2.get('environment', {})
+    value = env.get('NODE_PEERS', '')
+    if not value or 'backend1' not in value:
+        raise AssertionError(f"NODE_PEERS not configured correctly: {value}")
+

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -12,6 +12,10 @@ npm ci
 npm run test -- --run
 popd > /dev/null
 
+# Run lightweight regression checks
+pip install behave PyYAML >/tmp/pip.log
+behave pipeline-tests/compose_config.feature pipeline-tests/regression.feature
+
 # Build runtime image and start multi-node setup
 docker build -t simple-blockchain-node:runtime -f Dockerfile.backend .
 COMPOSE_FILE=docker-compose.ci.yml


### PR DESCRIPTION
## Summary
- add new compose_config.feature to assert NODE_PEERS is configured
- implement regression steps to load compose file and check backend2 peer config
- add GitHub Actions workflow running ci-local script
- regression checks now run as part of ci-local script

## Testing
- `behave pipeline-tests/compose_config.feature`
- `behave pipeline-tests/regression.feature`
- `behave pipeline-tests/e2e.feature` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bce0af61c8326b976d90eac2d7641