### PR TITLE
Add error registry to docs

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,3 +1,6 @@
-This directory currently has no active GitHub Actions workflows.
-A previous pipeline was removed. Local integration and regression tests
-under `pipeline-tests/` can be executed with `behave`.
+This directory hosts the GitHub Actions workflow defined in
+`workflows/ci.yml`. Local integration and regression tests under
+`pipeline-tests/` can be executed with `behave`.
+
+`[CI_MISMATCH]` - earlier revisions stated no workflows exist although
+`ci.yml` is present.

--- a/.vscode/AGENTS.md
+++ b/.vscode/AGENTS.md
@@ -1,0 +1,5 @@
+Launch and editor settings for developing with VS Code.
+- `launch.json` defines a Spring Boot run configuration for the backend using
+  the `.env` file.
+- `settings.json` enables automatic build configuration and null analysis for the
+  Java extension.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Directories and notable files
   - `src` holds React components and API helpers.
 - `gradle/` – Gradle wrapper and version catalog `libs.versions.toml`.
 - `data/` – runtime LevelDB store for blocks and wallet.
+- `pipeline-tests/` – Behave features validating multi-node sync and regression.
+- `scripts/` – local CI (`ci-local.sh`) and Docker health check scripts.
+- `.github/` – GitHub Actions workflow; see its `AGENTS.md`.
+- `.vscode/` – launch configuration for developing in VS Code.
 - `settings.gradle` – lists included modules.
 - `README.md` – build and usage instructions.
 - gRPC API available on `NODE_GRPC_PORT` (default 9090).
@@ -32,3 +36,21 @@ UI --> "blockchain-node": REST/WS calls
 ```
 
 Each module creates a `build/` directory with compiled classes and test reports after running Gradle. These outputs are not tracked in version control.
+Run `./scripts/ci-local.sh` to perform a full local build and execute the Behave scenarios under `pipeline-tests/`.
+
+Documentation tags
+-------------------
+- `[CI_MISMATCH]` - README mentions GitHub Actions but `.github/AGENTS.md` states none.
+- `[CI_REDUNDANT]` - Local CI described via `./scripts/ci-local.sh` here but `README.md` references `./gradlew ciLocal`.
+- `[DOC_BAD_TASK]` - README instructs running `./gradlew verify` which is not a defined Gradle task.
+
+Error categories
+----------------
+| Category | Tags | Description |
+|---------|------|-------------|
+| CI | `CI_MISMATCH`, `CI_REDUNDANT` | Inconsistent or duplicate CI documentation |
+| DOC | `DOC_BAD_TASK` | Invalid or outdated instructions |
+
+Principles
+----------
+Record mismatching, redundant or logically incorrect guidance with one of the tags above in the `AGENTS.md` located next to the offending file. Reuse existing categories where possible so the registry stays manageable.

--- a/blockchain-core/AGENTS.md
+++ b/blockchain-core/AGENTS.md
@@ -10,7 +10,8 @@ Packages under `src/main/java/blockchain/core`:
 - `serialization` – JSON helpers (`JsonUtils`).
 - `exceptions` – custom runtime `BlockchainException`.
 
-Proto definitions in `blockchain-node/src/main/proto` map these models for gRPC.
+Unit tests live under `src/test/java/simple/blockchain` mirroring these packages.
+They cover consensus rules, wallet operations and mempool edge cases.
 
-Tests in `src/test/java` mirror these packages. Build logic resides in
-`build.gradle`.
+`build.gradle` configures JDK 21 toolchains and generates JaCoCo reports.
+Proto definitions in `blockchain-node/src/main/proto` map these models for gRPC.

--- a/blockchain-core/src/main/java/blockchain/core/consensus/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/consensus/AGENTS.md
@@ -1,0 +1,5 @@
+This package defines consensus logic.
+
+- `Chain.java` — manages the block DAG, difficulty adjustment and reorganisations.
+- `ConsensusParams.java` — network-wide constants like block interval and reward schedule.
+- `Chain.java.agent.md` — extra notes describing the chain implementation.

--- a/blockchain-core/src/main/java/blockchain/core/crypto/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/crypto/AGENTS.md
@@ -1,0 +1,5 @@
+Cryptographic helpers.
+
+- `AddressUtils` — Base58-check addresses.
+- `Base58` — simple encoder/decoder.
+- `CryptoUtils` and `HashingUtils` — wrappers over JDK and BouncyCastle primitives.

--- a/blockchain-core/src/main/java/blockchain/core/exceptions/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/exceptions/AGENTS.md
@@ -1,0 +1,3 @@
+Contains project specific runtime exception.
+
+- `BlockchainException` — used when chain rules are violated.

--- a/blockchain-core/src/main/java/blockchain/core/mempool/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/mempool/AGENTS.md
@@ -1,0 +1,3 @@
+In-memory queue for pending transactions.
+
+- `Mempool.java` — thread-safe storage with validation helpers.

--- a/blockchain-core/src/main/java/blockchain/core/model/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/model/AGENTS.md
@@ -1,0 +1,6 @@
+Data model classes.
+
+- `Block` and `BlockHeader` — immutable structures with PoW fields.
+- `Transaction`, `TxInput`, `TxOutput` — UTXO-based transaction model.
+- `Wallet` — simple key pair wrapper.
+- `Block.java.agent.md` — explanation of mining helper.

--- a/blockchain-core/src/main/java/blockchain/core/serialization/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/serialization/AGENTS.md
@@ -1,0 +1,3 @@
+JSON serialization helpers using Jackson.
+
+- `JsonUtils.java` — converts models to and from JSON strings.

--- a/blockchain-core/src/test/java/simple/blockchain/AGENTS.md
+++ b/blockchain-core/src/test/java/simple/blockchain/AGENTS.md
@@ -1,0 +1,6 @@
+Unit tests for the core library.
+
+- `consensus/` — verifies chain rules and difficulty adjustment.
+- `crypto/` — covers address encoding and hashing helpers.
+- `mempool/` — tests edge cases in the Mempool.
+- `model/` — transaction serialization and validation.

--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -11,8 +11,13 @@ Important paths under `src/main/java/de/flashyotter/blockchain_node`:
 - `wallet/` – wallet and keystore utilities.
 - `grpc/` – service implementations from `src/main/proto`.
 
-Resources in `src/main/resources` define application defaults. Tests in
-`src/test` cover controllers, services and networking.
+gRPC and P2P message schemas are defined in `src/main/proto`. The module
+produces a runnable Spring Boot JAR via `build.gradle` which also configures
+protobuf code generation.
+
+Tests under `src/test` exercise REST controllers, services and networking
+components.
+
 
 ```plantuml
 @startuml

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/bootstrap/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/bootstrap/AGENTS.md
@@ -1,0 +1,3 @@
+Application startup utilities.
+
+- `StartupInitializer` — seeds peers and ensures the wallet is ready when the app starts.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
@@ -1,0 +1,6 @@
+Spring configuration classes.
+
+- Security and JWT setup in `SecurityConfig` and `JwtAuthFilter`.
+- Core beans under `NodeBeanConfig` and `CoreConsensusConfig`.
+- `WebSocketConfig` exposes STOMP endpoints.
+- `NodeProperties` maps application.yml into POJOs.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/AGENTS.md
@@ -1,0 +1,5 @@
+REST controllers for public APIs.
+
+- `ChainController`, `MiningController`, `TxController`, `WalletController` expose JSON endpoints.
+- `NodeController` provides node management operations.
+- `RestErrorHandler` converts exceptions into HTTP responses.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/AGENTS.md
@@ -1,0 +1,1 @@
+DTO classes shared by REST and gRPC APIs. Mostly record types serialised to JSON and protobuf.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/grpc/AGENTS.md
@@ -1,0 +1,4 @@
+Implements the gRPC services defined in `src/main/proto`.
+
+- `ChainGrpcService`, `MiningGrpcService`, `WalletGrpcService` delegate to the corresponding services.
+- `GrpcMapper` converts between protobuf messages and domain objects.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/health/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/health/AGENTS.md
@@ -1,0 +1,3 @@
+Custom Spring Boot health indicators.
+
+- `P2PHealthIndicator` checks libp2p connectivity for container health checks.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/AGENTS.md
@@ -1,0 +1,6 @@
+Peer-to-peer networking layer.
+
+- `Peer` represents a remote node (see `Peer.java.agent.md`).
+- `Libp2pConfig` wires up libp2p components.
+- `P2PProtoMapper` handles protobuf message conversion.
+- `libp2p/` contains `Libp2pService` running the network loop.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/AGENTS.md
@@ -1,0 +1,3 @@
+Libp2p-specific implementation.
+
+- `Libp2pService` starts the host and manages P2P message handlers.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/storage/AGENTS.md
@@ -1,0 +1,3 @@
+Blockchain persistence layer.
+
+- `BlockStore` interface with LevelDB, in-memory and write-ahead log implementations.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/wallet/AGENTS.md
@@ -1,0 +1,4 @@
+Wallet and keystore management.
+
+- `WalletService` persists keys and signs transactions.
+- `KeyStoreProvider` abstractions for `PkcsKeyStoreProvider` and `InMemoryKeyStore`.

--- a/blockchain-node/src/main/resources/AGENTS.md
+++ b/blockchain-node/src/main/resources/AGENTS.md
@@ -1,0 +1,5 @@
+Application configuration files.
+
+- `application.yml` - default Spring Boot settings.
+- `application-test.yml` - overrides used during tests.
+- `logback-spring.xml` - logging configuration.

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/AGENTS.md
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/AGENTS.md
@@ -1,0 +1,6 @@
+Integration and unit tests for the Spring Boot node.
+
+- `integration/` — end-to-end scenarios with multiple nodes.
+- `network/` — P2P communication tests.
+- `storage/` — verifies persistence implementations.
+- `service/`, `controller/`, `config/`, `wallet/` — component-level tests.

--- a/pipeline-tests/AGENTS.md
+++ b/pipeline-tests/AGENTS.md
@@ -1,0 +1,16 @@
+The `pipeline-tests` directory holds Behave BDD tests for this project.
+
+Features:
+- `e2e.feature` – launches two nodes and ensures blocks and transactions
+  propagate between them. Uses Selenium to verify the web dashboards.
+- `compose_config.feature` – validates environment variables in
+  `docker-compose.ci.yml`.
+- `regression.feature` – sanity checks that Gradle and NPM commands run.
+
+Step definitions reside in `steps/`:
+- `e2e_steps.py` connects via gRPC to the nodes and drives Selenium.
+- `regression_steps.py` executes CLI commands and inspects the compose file.
+
+Generated gRPC stubs `node_pb2*.py` are kept here for the tests.
+
+Run a scenario with `behave pipeline-tests/<feature>`.

--- a/pipeline-tests/steps/AGENTS.md
+++ b/pipeline-tests/steps/AGENTS.md
@@ -1,0 +1,6 @@
+Step definitions for Behave features.
+
+- `e2e_steps.py` provides helpers to wait for gRPC services, mine blocks, send
+  transactions and verify the dashboard via Selenium.
+- `regression_steps.py` runs shell commands and parses `docker-compose.ci.yml` to
+  ensure environment variables are set correctly.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,13 @@
+The `scripts` directory contains helper shell scripts used during development and CI.
+
+- `check_compose_health.sh` waits until all Docker Compose services report a
+  `healthy` status. The script checks containers up to forty times and exits with
+  an error if any service remains unhealthy.
+- `ci-local.sh` runs a local pipeline: builds the Java backend and UI, executes
+  their tests, spins up a two-node Docker Compose environment and runs the Behave
+  end-to-end scenario.
+
+Both scripts assume Docker and the compose files at the repository root are
+available on the host.
+
+`[CI_REDUNDANT]` - Script used by `make ci-local`; README instead documents a Gradle task.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -9,4 +9,7 @@ Key files:
 - `tsconfig*.json` – TypeScript compiler settings.
 - Communicates with the backend via REST and gRPC clients.
 
+Unit tests under `src/__tests__` run with Vitest. A Gradle task delegates to
+`npm test` so backend and frontend tests can be executed together.
+
 Run `npm install` then `npm run dev` in this directory to start the dev server.

--- a/ui/src/__tests__/AGENTS.md
+++ b/ui/src/__tests__/AGENTS.md
@@ -1,0 +1,1 @@
+Vitest unit tests covering React components and API helpers.

--- a/ui/src/api/AGENTS.md
+++ b/ui/src/api/AGENTS.md
@@ -1,0 +1,4 @@
+Client-side helpers for communicating with the backend.
+
+- `grpc.ts` – gRPC-web wrapper using generated stubs.
+- `ws.ts` – WebSocket convenience functions.

--- a/ui/src/components/AGENTS.md
+++ b/ui/src/components/AGENTS.md
@@ -1,0 +1,6 @@
+Reusable React components forming the dashboard UI.
+
+- `BlockHistory`, `BlockList` display recent chain data.
+- `MiningArea` starts manual mining.
+- `Transfer` and `WalletView` show wallet details.
+- `StatCard` renders small metric panels.

--- a/ui/src/pages/AGENTS.md
+++ b/ui/src/pages/AGENTS.md
@@ -1,0 +1,3 @@
+High level pages of the app.
+
+- `Dashboard.tsx` – main page showing node stats and wallet operations (see `Dashboard.tsx.agent.md`).

--- a/ui/src/services/AGENTS.md
+++ b/ui/src/services/AGENTS.md
@@ -1,0 +1,4 @@
+Generated gRPC client files and small helpers.
+
+- `node_pb.js` and `node_pb.d.ts` – protobuf stubs.
+- `messageService.tsx` – React context using the gRPC service.

--- a/ui/src/types/AGENTS.md
+++ b/ui/src/types/AGENTS.md
@@ -1,0 +1,1 @@
+Shared TypeScript interfaces describing blocks and P2P messages.


### PR DESCRIPTION
## Summary
- document workflow presence in `.github`
- record README's invalid command and tag categories in root docs
- cross-link redundant CI instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d261b232c832690ac55e76eada58b