### PR TITLE
Document peer address parsing flaw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,22 @@ Documentation tags
 - `[CI_MISMATCH]` - README mentions GitHub Actions but `.github/AGENTS.md` states none.
 - `[CI_REDUNDANT]` - Local CI described via `./scripts/ci-local.sh` here but `README.md` references `./gradlew ciLocal`.
 - `[DOC_BAD_TASK]` - README instructs running `./gradlew verify` which is not a defined Gradle task.
+- `[DOC_BAD_ENV]`  - `.env` uses `MINING_THREADS` but the code expects `NODE_MINING_THREADS`.
+- `[DOC_BAD_ADDR]` - README says `NODE_PEERS` accepts multiaddresses but the code expects `host:port` pairs.
 
 Error categories
 ----------------
 | Category | Tags | Description |
 |---------|------|-------------|
 | CI | `CI_MISMATCH`, `CI_REDUNDANT` | Inconsistent or duplicate CI documentation |
-| DOC | `DOC_BAD_TASK` | Invalid or outdated instructions |
+| DOC | `DOC_BAD_TASK`, `DOC_BAD_ENV`, `DOC_BAD_ADDR` | Invalid or outdated instructions |
+| LOGIC | `LOGIC_BAD_CHECK`, `LOGIC_BAD_HASH`, `LOGIC_RESOURCE_LEAK`, `LOGIC_BAD_ORDER`, `LOGIC_MINING_LOOP`, `LOGIC_BAD_ADDR` | Flawed or inconsistent code logic |
 
 Principles
 ----------
 Record mismatching, redundant or logically incorrect guidance with one of the tags above in the `AGENTS.md` located next to the offending file. Reuse existing categories where possible so the registry stays manageable.
+
+Errors
+------
+- `[DOC_BAD_ENV]` - .env uses MINING_THREADS instead of NODE_MINING_THREADS.
+- `[DOC_BAD_ADDR]` - README claims NODE_PEERS accepts multiaddresses but NodeProperties expects host:port.

--- a/blockchain-core/src/main/java/blockchain/core/consensus/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/consensus/AGENTS.md
@@ -3,3 +3,8 @@ This package defines consensus logic.
 - `Chain.java` — manages the block DAG, difficulty adjustment and reorganisations.
 - `ConsensusParams.java` — network-wide constants like block interval and reward schedule.
 - `Chain.java.agent.md` — extra notes describing the chain implementation.
+
+Errors
+------
+- `[LOGIC_BAD_CHECK]` - `Chain.java` uses `MAX_BLOCK_SIZE_BYTES` for both
+  byte size and transaction count validation.

--- a/blockchain-core/src/main/java/blockchain/core/mempool/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/mempool/AGENTS.md
@@ -1,3 +1,7 @@
 In-memory queue for pending transactions.
 
 - `Mempool.java` — thread-safe storage with validation helpers.
+
+Errors
+------
+- `[LOGIC_BAD_CHECK]` - `calcFee` allows transactions with outputs exceeding inputs, yielding negative fees.

--- a/blockchain-core/src/main/java/blockchain/core/model/AGENTS.md
+++ b/blockchain-core/src/main/java/blockchain/core/model/AGENTS.md
@@ -4,3 +4,8 @@ Data model classes.
 - `Transaction`, `TxInput`, `TxOutput` — UTXO-based transaction model.
 - `Wallet` — simple key pair wrapper.
 - `Block.java.agent.md` — explanation of mining helper.
+
+Errors
+------
+- `[LOGIC_BAD_HASH]` - `Transaction` concatenates fields without delimiters
+  when computing the hash, leading to potential collisions.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
@@ -4,3 +4,9 @@ Spring configuration classes.
 - Core beans under `NodeBeanConfig` and `CoreConsensusConfig`.
 - `WebSocketConfig` exposes STOMP endpoints.
 - `NodeProperties` maps application.yml into POJOs.
+
+Errors
+------
+- `[LOGIC_BAD_ADDR]` - `NodeProperties` splits `NODE_PEERS` by `:` and converts the second
+  segment to an int. Multiaddresses like `/dns4/node/tcp/4001/p2p/ID` therefore
+  cause a `NumberFormatException` during startup.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/AGENTS.md
@@ -15,3 +15,14 @@ NodeService -> MempoolService: submitTx()
 NodeService -> P2PBroadcastService: broadcast()
 @enduml
 ```
+
+Errors
+------
+- `[LOGIC_RESOURCE_LEAK]` - `SnapshotService.compactSnapshots` does not close
+  the directory stream returned by `Files.list`, leaking file handles.
+- `[LOGIC_BAD_ORDER]` - `NodeService.blockPage` returns pages in ascending order
+  despite claiming a descending view.
+- `[LOGIC_MINING_LOOP]` - `MiningService.mine` increments the nonce several
+  times before re-checking the proof, skipping candidate hashes.
+- `[LOGIC_BAD_CHECK]` - `PeerRegistry.addAll` adds peers without marking them
+  pending for dialing.


### PR DESCRIPTION
## Summary
- add DOC_BAD_ADDR and LOGIC_BAD_ADDR tags
- log README mismatch about NODE_PEERS
- note NodeProperties crash on multiaddresses

## Testing
- `./gradlew test --no-daemon`
- `(cd ui && npm test -- --run)`
- `(cd ui && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_687d432f1e208326be86983da64ec988