### PR TITLE
Fix redundant Python deps step

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,3 +1,6 @@
 This directory hosts the GitHub Actions workflow defined in
 `workflows/ci.yml`. The workflow invokes `make ci` to run all tests.
 
+CI_REDUNDANT: Removed the explicit Python install step from the workflow since
+`make ci` already installs the same dependencies.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Install Python deps
-        run: pip install pytest PyYAML
       - name: Run pipeline
         run: make ci


### PR DESCRIPTION
## Summary
- remove explicit Python deps installation from GitHub Actions workflow
- note redundancy in `.github/AGENTS.md`

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_687de7f73e2c8326b6be109f5647bce1