### PR TITLE
Fix compose tests with local image build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,5 @@
 ## Unreleased
 - Pipeline Green Story: added local CI script and improved sync waiting in E2E tests.
 - Removed Behave-based pipeline and local CI script in favour of `make ci`.
-- Docker Compose uses prebuilt `simple-blockchain-node:runtime` image for faster startup.
+- Docker Compose builds `simple-blockchain-node:runtime` if not present to avoid missing-image errors.
 - Backend2 waits for backend1 health before starting.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A lean Java&nbsp;21 and Spring Boot&nbsp;3 blockchain node demonstrating a moder
 - Prometheus metrics exported at `/actuator/prometheus`
 - gRPC API for chain, wallet and mining operations
 - Compose tasks `composeUp` and `composeDown` manage Docker
+- If the runtime image `simple-blockchain-node:runtime` doesn't exist
+  locally, Compose builds it automatically from `Dockerfile.backend`.
 - Write-ahead log for replay-safe LevelDB storage
 - Compressed UTXO snapshots tracked via manifest
 - Structured JSON logging with Prometheus metrics

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,6 +2,9 @@
 services:
   backend1:
     image: simple-blockchain-node:runtime
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
     environment:
       SERVER_PORT: 3333
       NODE_LIBP2P_PORT: 4001
@@ -40,6 +43,9 @@ services:
 
   backend2:
     image: simple-blockchain-node:runtime
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
     depends_on:
       backend1:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- build runtime image when running docker compose to avoid pull failures
- update README about compose auto build
- document the new behaviour in the changelog

## Testing
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_687e54e9b66c8326868cf81bda8c256b