### PR TITLE
Document updated P2P endpoints

### DIFF
--- a/blockchain-node/AGENTS.md
+++ b/blockchain-node/AGENTS.md
@@ -5,6 +5,8 @@ Important paths under `src/main/java/de/flashyotter/blockchain_node`:
 - `bootstrap/StartupInitializer.java` – tasks executed at startup.
 - `config/` – Spring configuration classes (`SecurityConfig`, `P2PConfig`, ...).
 - `controller/` – REST controllers for chain, mining, transactions and wallet.
+  `NodeController` exposes `/node/enr` and `SnapshotController` serves snapshot
+  files for syncing.
 - `service/` – business logic (`NodeService`, `MiningService`, etc.).
 - `p2p/` – `Peer`, `PeerClient` and `PeerServer` for libp2p networking.
 - `storage/` – `BlockStore` with LevelDB and in-memory implementations.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/AGENTS.md
@@ -4,4 +4,5 @@ Spring configuration classes.
 - Core beans under `NodeBeanConfig` and `CoreConsensusConfig`.
 - `WebSocketConfig` exposes STOMP endpoints.
 - `NodeProperties` maps application.yml into POJOs.
+  It now also configures `libp2pKeyPath` for storing the libp2p private key.
 

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/config/NodeProperties.java.agent.md
@@ -1,0 +1,1 @@
+Loads application.yml and environment variables into a POJO. Provides configuration such as ports, snapshot settings and wallet password. Recent P2P updates introduced `libp2pKeyPath` which stores the libp2p private key on disk and is resolved relative to `dataPath`.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/AGENTS.md
@@ -1,5 +1,6 @@
 REST controllers for public APIs.
 
 - `ChainController`, `MiningController`, `TxController`, `WalletController` expose JSON endpoints.
-- `NodeController` provides node management operations.
+- `NodeController` provides node management operations including `/node/enr`.
+- `SnapshotController` serves UTXO snapshot files to peers.
 - `RestErrorHandler` converts exceptions into HTTP responses.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/NodeController.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/NodeController.java.agent.md
@@ -1,0 +1,1 @@
+Exposes node information over REST. `/node/id` returns the stable node UUID, `/node/peer-id` returns the libp2p peer ID and `/node/enr` publishes the node's multiaddress for discovery.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/SnapshotController.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/controller/SnapshotController.java.agent.md
@@ -1,0 +1,1 @@
+Downloads of compressed UTXO snapshots for fast syncing. `/snap/{height}` streams the snapshot file from `${dataPath}/snapshots` if present and responds 404 otherwise.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/dto/AGENTS.md
@@ -1,1 +1,2 @@
-DTO classes shared by REST and gRPC APIs. Mostly record types serialised to JSON and protobuf.
+DTO classes shared by REST and gRPC APIs. Mostly record types serialised to JSON
+and protobuf. Recent additions include `EnrDto` returned by `/node/enr`.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/AGENTS.md
@@ -3,4 +3,7 @@ Peer-to-peer networking layer.
 - `Peer` represents a remote node (see `Peer.java.agent.md`).
 - `Libp2pConfig` wires up libp2p components.
 - `P2PProtoMapper` handles protobuf message conversion.
-- `libp2p/` contains `Libp2pService` running the network loop.
+- `libp2p/` contains `Libp2pService` running the network loop and persisting the
+  private key configured via `NodeProperties.libp2pKeyPath`.
+Handshakes now announce the REST API port and peer ID so nodes can discover each
+other without extra lookups.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
@@ -1,3 +1,4 @@
-Represents a remote blockchain node. Provides the `wsUrl()` helper to build the
-WebSocket endpoint and a `fromString` factory to parse `host:port` pairs. Used by
-`PeerService` and networking tests.
+Represents a remote blockchain node. Stores both the REST API port and the
+libp2p port plus an optional peer ID. `wsUrl()` builds the WebSocket endpoint
+using the REST port while `multiAddr()` derives the libp2p multiaddress.
+`fromString` still parses the canonical `host:port` form for convenience.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/AGENTS.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/AGENTS.md
@@ -1,3 +1,4 @@
 Libp2p-specific implementation.
 
-- `Libp2pService` starts the host and manages P2P message handlers.
+- `Libp2pService` starts the host, exposes `enr()` for the advertised address and
+  persists the private key between restarts.

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/AGENTS.md
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/AGENTS.md
@@ -3,4 +3,5 @@ Integration and unit tests for the Spring Boot node.
 - `integration/` — end-to-end scenarios with multiple nodes.
 - `network/` — P2P communication tests.
 - `storage/` — verifies persistence implementations.
-- `service/`, `controller/`, `config/`, `wallet/` — component-level tests.
+- `service/`, `controller/`, `config/`, `wallet/` — component-level tests. Recent
+  additions cover `/node/enr` and snapshot downloads.


### PR DESCRIPTION
## Summary
- document new endpoints and persisted libp2p key in agent notes
- add agent files for NodeProperties and snapshot endpoints

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_687e5e66944883269c1af94232b6a5ed