### PR TITLE
Fix health check in CI containers

### DIFF
--- a/AGENTS_LOG.md
+++ b/AGENTS_LOG.md
@@ -8,3 +8,4 @@
   use these running services.
 - Added a Gradle build step in the workflow to ensure the project compiles
   before launching the Compose services.
+- Added curl to the runtime Docker image so health checks succeed.

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -7,6 +7,9 @@ RUN gradle :blockchain-node:bootJar --no-daemon
 
 # Run stage
 FROM eclipse-temurin:21-jre
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
 ARG SERVER_PORT=3333
 ENV SERVER_PORT=${SERVER_PORT}
 WORKDIR /app


### PR DESCRIPTION
## Summary
- install curl in runtime Dockerfile so healthchecks work
- log update in AGENTS_LOG

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_687e6a1147508326b3c9c44243f6c3bf