### PR TITLE
Fix compose peer port

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ Use `data2`/`wallet2` etc. for additional nodes.
 
 ### 3. Connect peers
 
-Set `NODE_PEERS` to a comma-separated list of `host:port` pairs and expose
-`NODE_LIBP2P_PORT` so others can dial your node.
+Set `NODE_PEERS` to a comma-separated list of `host:restPort` pairs (the REST
+API port of each peer) and expose your own `NODE_LIBP2P_PORT` so others can
+dial your node.
 
 ### 4. Stop
 
@@ -132,6 +133,7 @@ the `make ci` target. The workflow first builds the project via Gradle, then
 starts the containers defined in `docker-compose.ci.yml` and waits until they
 are healthy. The Python end-to-end tests simply connect to these running
 services instead of managing Docker Compose themselves.
+When Docker is not available, those e2e tests are skipped automatically.
 
 ## Contributing
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -45,7 +45,7 @@ services:
     environment:
       SERVER_PORT: 3334
       NODE_LIBP2P_PORT: 4002
-      NODE_PEERS: "${BACKEND1_MULTIADDR:-backend1:4001}"
+      NODE_PEERS: "${BACKEND1_MULTIADDR:-backend1:3333}"
       NODE_JWT_SECRET: changeMeSuperSecret
       NODE_WALLET_PASSWORD: changeMeSuperSecret
       NODE_GRPC_PORT: 9091


### PR DESCRIPTION
## Summary
- fix backend2 peer address in docker compose
- clarify peer port usage in README
- document that e2e tests skip when Docker is unavailable

## Testing
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_687ef73e19fc832680636f773ecb41b8