### PR TITLE
UI node id badge

### DIFF
--- a/ui/src/__tests__/dashboard.test.tsx
+++ b/ui/src/__tests__/dashboard.test.tsx
@@ -26,6 +26,10 @@ vi.mock('../components/BlockHistory', () => ({
   __esModule: true,
   default: () => <div data-testid="block-history" />,
 }));
+vi.mock('../components/NodeIdBadge', () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-id" />,
+}));
 
 /* useSWR stubben, damit Chain-Info sofort im State ist -------------------- */
 vi.mock('swr', () => ({
@@ -48,6 +52,7 @@ describe('<Dashboard />', () => {
     expect(screen.getByText(/difficulty bits/i)).toBeInTheDocument();
     expect(screen.getByText(/latest hash/i)).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByTestId('node-id')).toBeInTheDocument();
     expect(screen.getByTestId('wallet-view')).toBeInTheDocument();
     expect(screen.getByTestId('block-list')).toBeInTheDocument();
     expect(screen.getByTestId('block-history')).toBeInTheDocument();

--- a/ui/src/__tests__/nodeidbadge.test.tsx
+++ b/ui/src/__tests__/nodeidbadge.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import NodeIdBadge from '../components/NodeIdBadge';
+
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: () => ({ data: 'node-abc' }),
+}));
+
+describe('<NodeIdBadge />', () => {
+  it('shows node id', () => {
+    render(<NodeIdBadge />);
+    expect(screen.getByText('node-abc')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/NodeIdBadge.tsx
+++ b/ui/src/components/NodeIdBadge.tsx
@@ -1,0 +1,22 @@
+import useSWR from 'swr';
+import { ServerStackIcon } from '@heroicons/react/24/outline';
+
+const base = (import.meta.env.VITE_NODE_URL || '').replace(/\/api$/, '');
+
+async function fetchNodeId() {
+  const res = await fetch(`${base}/node/id`);
+  if (!res.ok) throw new Error(res.statusText);
+  const data = await res.json();
+  return data.nodeId as string;
+}
+
+export default function NodeIdBadge() {
+  const { data } = useSWR<string>('/node/id', fetchNodeId);
+  if (!data) return null;
+  return (
+    <div className="flex items-center text-sm text-slate-700" aria-label="node-id">
+      <ServerStackIcon className="mr-1 h-5 w-5 text-slate-500" aria-hidden="true" />
+      <span className="font-mono">{data}</span>
+    </div>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { StatCard } from '../components/StatCard';
 import WalletView from '../components/WalletView';
 import BlockList from '../components/BlockList';
 import BlockHistory from '../components/BlockHistory';
+import NodeIdBadge from '../components/NodeIdBadge';
 
 export default function Dashboard() {
   const { data: tip } = useSWR<Block>(
@@ -15,6 +16,9 @@ export default function Dashboard() {
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-6 grid gap-6 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <NodeIdBadge />
+      </div>
       <section className="space-y-4" aria-label="chain info">
         <h2 className="text-lg font-semibold">Chain info</h2>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">


### PR DESCRIPTION
## Summary
- display node id on dashboard
- fetch `/node/id` via new `NodeIdBadge` component
- test new badge and update dashboard tests

## Testing
- `npm test --prefix ui -- --run src/__tests__/nodeidbadge.test.tsx`
- `npm test --prefix ui`
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_687f9b199d2c8326823109785fd02eae