### PR TITLE
Polish JSON-RPC module and tests

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/rpc/SimpleRpcHandler.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/rpc/SimpleRpcHandler.java
@@ -3,7 +3,6 @@ package de.flashyotter.blockchain_node.rpc;
 import blockchain.core.model.Block;
 import blockchain.core.model.Transaction;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,7 +14,6 @@ import java.util.Map;
 /**
  * Basic RPC handler bridging to NodeService.
  */
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class SimpleRpcHandler implements RpcHandler {
@@ -33,13 +31,18 @@ public class SimpleRpcHandler implements RpcHandler {
             case "getBlockByNumber" -> {
                 int height = params.get(0).asInt();
                 Block b = node.blocksFromHeight(height).stream().findFirst().orElse(null);
-                yield b;
+                yield b != null ? b : Map.of("error", "Block not found");
             }
             case "sendTransaction" -> {
                 String raw = params.get(0).asText();
-                Transaction tx = blockchain.core.serialization.JsonUtils.txFromJson(raw);
-                node.submitTx(tx);
-                yield Map.of("hash", tx.calcHashHex());
+                try {
+                    Transaction tx = blockchain.core.serialization.JsonUtils.txFromJson(raw);
+                    node.submitTx(tx);
+                    yield Map.of("hash", tx.calcHashHex());
+                } catch (Exception e) {
+                    log.error("Failed to deserialize transaction from JSON: {}", raw, e);
+                    yield Map.of("error", "Invalid transaction format");
+                }
             }
             default -> {
                 log.warn("Unknown RPC method {}", method);

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/rpc/SimpleRpcHandlerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/rpc/SimpleRpcHandlerTest.java
@@ -24,4 +24,22 @@ class SimpleRpcHandlerTest {
         Object result = handler.dispatch("getBalance", mapper.readTree("[\"addr\"]"));
         assertEquals(5.0, ((Map<?,?>)result).get("balance"));
     }
+
+    @Test
+    void missingBlockReturnsError() throws Exception {
+        NodeService node = mock(NodeService.class);
+        when(node.blocksFromHeight(anyInt())).thenReturn(java.util.List.of());
+        SimpleRpcHandler handler = new SimpleRpcHandler(node);
+        Object result = handler.dispatch("getBlockByNumber", mapper.readTree("[1]"));
+        assertEquals("Block not found", ((Map<?,?>)result).get("error"));
+    }
+
+    @Test
+    void invalidTransactionReturnsError() throws Exception {
+        NodeService node = mock(NodeService.class);
+        SimpleRpcHandler handler = new SimpleRpcHandler(node);
+        Object result = handler.dispatch("sendTransaction", mapper.readTree("[\"invalid\"]"));
+        assertEquals("Invalid transaction format", ((Map<?,?>)result).get("error"));
+        verify(node, never()).submitTx(any());
+    }
 }

--- a/blockchain-rpc/src/main/java/de/flashyotter/blockchain_rpc/JsonRpcController.java
+++ b/blockchain-rpc/src/main/java/de/flashyotter/blockchain_rpc/JsonRpcController.java
@@ -24,9 +24,20 @@ public class JsonRpcController {
 
     @PostMapping(value = "/rpc", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<String, Object> handle(@RequestBody JsonNode req) {
+        if (!req.has("method") || req.get("method").isNull() || !req.has("id") || req.get("id").isNull()) {
+            Map<String, Object> err = new java.util.HashMap<>();
+            err.put("jsonrpc", "2.0");
+            err.put("error", Map.of(
+                    "code", -32600,
+                    "message", "Invalid Request: 'method' and 'id' fields are required"
+            ));
+            err.put("id", req.has("id") ? req.get("id") : null);
+            return err;
+        }
+
         String method = req.get("method").asText();
         JsonNode params = req.get("params");
-        Object id = req.get("id");
+        JsonNode id = req.get("id");
         Object result = handler.dispatch(method, params);
         return Map.of(
                 "jsonrpc", "2.0",

--- a/blockchain-rpc/src/test/java/de/flashyotter/blockchain_rpc/JsonRpcControllerTest.java
+++ b/blockchain-rpc/src/test/java/de/flashyotter/blockchain_rpc/JsonRpcControllerTest.java
@@ -39,4 +39,15 @@ class JsonRpcControllerTest {
                 .expectBody()
                 .jsonPath("$.result").isEqualTo("pong");
     }
+
+    @Test
+    void rejectsInvalidRequest() throws Exception {
+        client.post()
+                .uri("/rpc")
+                .bodyValue(mapper.readTree("{\"jsonrpc\":\"2.0\"}"))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.error.code").isEqualTo(-32600);
+    }
 }


### PR DESCRIPTION
## Summary
- handle invalid JSON-RPC requests gracefully
- return error object when block not found
- guard transaction deserialization
- add unit tests for new behaviour
- cover invalid transaction case

## Testing
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_688c27ca04e08326ae875f45e8463063