### PR TITLE
Peer cleanup and libp2p improvements

### DIFF
--- a/blockchain-core/build.gradle
+++ b/blockchain-core/build.gradle
@@ -25,13 +25,13 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType(JavaCompile).configureEach {
     javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -42,4 +42,8 @@ tasks.named('test') {
 
 tasks.named('jacocoTestReport') {
     dependsOn test
+}
+
+jacoco {
+    toolVersion = "0.8.11"
 }

--- a/blockchain-node/build.gradle
+++ b/blockchain-node/build.gradle
@@ -10,7 +10,7 @@ group   = 'de.flashyotter'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    toolchain { languageVersion = JavaLanguageVersion.of(17) }
+    toolchain { languageVersion = JavaLanguageVersion.of(21) }
 }
 
 configurations {
@@ -87,7 +87,7 @@ tasks.named('test') {
 }
 
 jacoco {
-    toolVersion = "0.8.8" // Use a compatible version
+    toolVersion = "0.8.11"
 }
 
 tasks.named('jacocoTestReport') {

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java
@@ -23,12 +23,6 @@ public class Peer {
         this(host, restPort, libp2pPort, null);
     }
 
-    /** WebSocket URL of this peer’s raw-JSON P2P endpoint. */
-    public String wsUrl() {
-        // was "/p2p" but our server registers on "/ws"
-        return "ws://" + host + ':' + restPort + "/ws";
-    }
-
     /** Multiaddr for libp2p connections. */
     public String multiAddr() {
         String prefix;

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/Peer.java.agent.md
@@ -1,4 +1,3 @@
-Represents a remote blockchain node. Stores both the REST API port and the
-libp2p port plus an optional peer ID. `wsUrl()` builds the WebSocket endpoint
-using the REST port while `multiAddr()` derives the libp2p multiaddress.
-`fromString` still parses the canonical `host:port` form for convenience.
+Represents a remote blockchain node. Stores the REST API port, the libp2p port
+and an optional peer ID. `multiAddr()` derives the libp2p multiaddress while
+`fromString` parses the canonical `host:port` form for convenience.

--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/p2p/libp2p/Libp2pService.java
@@ -262,7 +262,11 @@ public class Libp2pService {
                     }
                     if (ctx.channel().remoteAddress() instanceof java.net.InetSocketAddress isa) {
                         String host = isa.getAddress().getHostAddress();
-                        kademlia.store(new Peer(host, hs.restPort(), hs.listenPort(), hs.peerId()));
+                        if (hs.restPort() > 0 && hs.listenPort() > 0) {
+                            kademlia.store(new Peer(host, hs.restPort(), hs.listenPort(), hs.peerId()));
+                        } else {
+                            log.debug("Ignoring handshake with zero ports from {}", host);
+                        }
                     }
                 } else if (dto instanceof FindNodeDto find) {
                     var nearest = kademlia.closest(find.nodeId(), 16)
@@ -334,7 +338,9 @@ public class Libp2pService {
                         .thenCompose(c -> host.newStream(protocol, c).getStream());
             }
             byte[] data = buf.array();
-            fut.thenAccept(s -> s.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(data))).join();
+            fut.orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+               .thenAccept(s -> s.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(data)))
+               .exceptionally(ex -> { log.warn("libp2p send failed", ex); return null; });
         } catch (Exception e) {
             log.warn("libp2p send failed", e);
         }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/p2p/PeerTest.java
@@ -8,12 +8,6 @@ import org.junit.jupiter.api.Test;
 class PeerTest {
 
     @Test
-    void wsUrlFormatsCorrectly() {
-        Peer p = new Peer("example.com", 4242);
-        assertEquals("ws://example.com:4242/ws", p.wsUrl());
-    }
-
-    @Test
     void multiAddrUsesDnsForHostnames() {
         Peer p = new Peer("example.com", 0, 4001);
         assertEquals("/dns4/example.com/tcp/4001", p.multiAddr());

--- a/blockchain-rpc/build.gradle
+++ b/blockchain-rpc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 java {
-    toolchain { languageVersion = JavaLanguageVersion.of(17) }
+    toolchain { languageVersion = JavaLanguageVersion.of(21) }
 }
 
 tasks.named('test') {
@@ -24,7 +24,7 @@ tasks.named('test') {
 }
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.11"
 }
 
 tasks.named('jacocoTestReport') {


### PR DESCRIPTION
## Summary
- remove unused wsUrl helper and its test
- document Peer class without the legacy method
- ignore invalid handshake ports to keep peer table clean
- avoid join() when sending over libp2p
- use Java 21 toolchain so tests run

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_688d0d7f3dd083268800d872a4c4109a