### PR TITLE
Fix Kademlia peer store initialization

### DIFF
--- a/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/TablePeerStore.java
+++ b/blockchain-node/src/main/java/de/flashyotter/blockchain_node/service/TablePeerStore.java
@@ -13,14 +13,23 @@ import java.lang.reflect.Method;
 public class TablePeerStore implements PeerStore {
     private static final Method ADD_METHOD;
     static {
-        Method candidate = null;
+        Method preferred = null;
+        Method fallback = null;
         for (Method m : KademliaRoutingTable.class.getDeclaredMethods()) {
-            if (m.getName().equals("add") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == Peer.class) {
+            if (m.getName().equals("add") && m.getParameterCount() == 1) {
+                // Prefer the variant returning the added peer to avoid the unmodifiable
+                // Set.add implementation. Fallback to the boolean-returning method if
+                // older library versions do not expose the former.
                 m.setAccessible(true);
-                candidate = m;
-                break;
+                if (m.getReturnType() == boolean.class) {
+                    fallback = m;
+                } else {
+                    preferred = m;
+                    break;
+                }
             }
         }
+        Method candidate = preferred != null ? preferred : fallback;
         if (candidate == null) {
             throw new ExceptionInInitializerError("KademliaRoutingTable.add method not found");
         }
@@ -36,7 +45,10 @@ public class TablePeerStore implements PeerStore {
     @Override
     public void addPeer(Peer peer) {
         try {
-            ADD_METHOD.invoke(table, peer);
+            Object result = ADD_METHOD.invoke(table, peer);
+            if (ADD_METHOD.getReturnType() == boolean.class && Boolean.FALSE.equals(result)) {
+                throw new IllegalStateException("Failed to add peer", null);
+            }
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to add peer", e);
         }

--- a/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/TablePeerStoreTest.java
+++ b/blockchain-node/src/test/java/de/flashyotter/blockchain_node/service/TablePeerStoreTest.java
@@ -1,0 +1,47 @@
+package de.flashyotter.blockchain_node.service;
+
+import de.flashyotter.blockchain_node.p2p.Peer;
+import org.apache.tuweni.kademlia.KademliaRoutingTable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TablePeerStoreTest {
+
+    private TablePeerStore store;
+    private KademliaRoutingTable<Peer> table;
+
+    @BeforeEach
+    void setUp() {
+        table = KademliaRoutingTable.create(
+                "self".getBytes(StandardCharsets.UTF_8),
+                16,
+                p -> p.toString().getBytes(StandardCharsets.UTF_8),
+                p -> 0);
+        store = new TablePeerStore(table);
+    }
+
+    @Test
+    void addPeerAddsToTable() {
+        Peer peer = new Peer("h", 1);
+        store.addPeer(peer);
+        assertTrue(table.contains(peer));
+    }
+
+    @Test
+    void removePeerEvictsFromTable() {
+        Peer peer = new Peer("h", 1);
+        store.addPeer(peer);
+        store.removePeer(peer);
+        assertFalse(table.contains(peer));
+    }
+
+    @Test
+    void removingMissingPeerThrows() {
+        Peer peer = new Peer("h", 1);
+        assertThrows(IllegalStateException.class, () -> store.removePeer(peer));
+    }
+}


### PR DESCRIPTION
## Summary
- resolve Kademlia peer store initialization by reflecting over available `add` method variants
- ensure peer additions fail fast if boolean-returning `add` rejects the peer

## Testing
- `./gradlew blockchain-node:test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_688f41eeee3c832690884e04af88561a