### PR TITLE
Start compose stack before pytest in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ ci:
 	NODE_MINER_ADDRESS=testMinerAddress NODE_JWT_SECRET=changeMeSuperSecret_changeMeSuperSecret ./gradlew clean test --no-daemon
 	cd ui && npm ci && npm test -- --run
 	pip install --quiet pytest PyYAML requests PyJWT
-	NODE_JWT_SECRET=changeMeSuperSecret_changeMeSuperSecret pytest -q
+	NODE_JWT_SECRET=changeMeSuperSecret_changeMeSuperSecret scripts/run_pytest_with_compose.sh pytest -q

--- a/PIPELINE_PLAN.md
+++ b/PIPELINE_PLAN.md
@@ -6,3 +6,10 @@ This file tracks the major steps used to refactor the CI pipeline.
 4. Removed Docker health checks from Compose and the workflow. Containers now
    start without curl and logs are captured after tests.
 5. Dropped Behave from the Makefile so only pytest runs during CI.
+6. Regression: the new Python e2e test `test_e2e_compose` expects the
+   Docker Compose stack from `docker-compose.ci.yml` to be running, but the
+   current workflow only executes `make ci` (Gradle, npm and pytest) without
+   starting Compose. As a result `wait_for_rpc` fails to reach
+   `http://localhost:3333/rpc`. Task: restore an automated `docker compose up`
+   plus health check step before pytest (either in `make ci` or the workflow) so
+   the services are available during the test suite.

--- a/scripts/run_pytest_with_compose.sh
+++ b/scripts/run_pytest_with_compose.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.ci.yml}
+SERVICES=(${SERVICES:-backend1 backend2})
+CMD=("$@")
+
+if [ ${#CMD[@]} -eq 0 ]; then
+    echo "Usage: $0 <pytest arguments>" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker command not found" >&2
+    exit 1
+fi
+
+cleanup() {
+    docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+rm -rf data1 data2
+
+docker compose -f "$COMPOSE_FILE" up -d --build "${SERVICES[@]}"
+
+# give services a moment to boot before handing over to pytest; tests also wait
+sleep 5
+
+"${CMD[@]}"


### PR DESCRIPTION
## Summary
- wrap the pytest stage in `make ci` with a helper that brings up the docker-compose stack first
- add a shell script that rebuilds the runtime services, clears old chain data, and tears the stack down after tests

## Testing
- `NODE_MINER_ADDRESS=testMinerAddress NODE_JWT_SECRET=changeMeSuperSecret_changeMeSuperSecret ./gradlew clean test --no-daemon --console=plain`
- `npm ci`
- `npm test -- --run`
- `NODE_JWT_SECRET=changeMeSuperSecret_changeMeSuperSecret scripts/run_pytest_with_compose.sh pytest -q` *(fails: Docker daemon unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a9c03ff88326a311fd1f3aada3ba